### PR TITLE
Show more information on the spawner options page

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -23,4 +23,4 @@ tljh_custom_jupyterhub_config(c)
 c.JupyterHub.authenticator_class = DummyAuthenticator
 
 user = getpass.getuser()
-c.Authenticator.admin_users = {user}
+c.Authenticator.admin_users = {user, 'alice'}

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -16,7 +16,7 @@ from .images import list_images, client
 CPU_PERIOD = 100_000
 
 
-class R2DSpawnerMixin(Configurable):
+class SpawnerMixin(Configurable):
     """
     Mixin for spawners that derive from DockerSpawner, to use local Docker images
     built with tljh-repo2docker.
@@ -134,7 +134,7 @@ class R2DSpawnerMixin(Configurable):
             }
 
 
-class R2DSpawner(R2DSpawnerMixin, DockerSpawner):
+class R2DSpawner(SpawnerMixin, DockerSpawner):
     """
     A custom spawner for using local Docker images built with tljh-repo2docker.
     """

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -2,10 +2,12 @@ import os
 import sys
 
 from dockerspawner import DockerSpawner
+from jinja2 import Environment, BaseLoader
 from jupyter_client.localinterfaces import public_ips
 from tljh.hooks import hookimpl
 from tljh.configurer import load_config, CONFIG_FILE
-from traitlets import default, validate
+from traitlets import default, validate, Unicode
+from traitlets.config import Configurable
 
 from .images import list_images, client
 
@@ -14,19 +16,76 @@ from .images import list_images, client
 CPU_PERIOD = 100_000
 
 
-class TLJHDockerSpawner(DockerSpawner):
-    def set_limits(self):
-        imagename = self.user_options.get("image")
-        image = client.images.get(imagename)
-        mem_limit = image.labels.get("tljh_repo2docker.mem_limit", None)
-        cpu_limit = image.labels.get("tljh_repo2docker.cpu_limit", None)
-        self.mem_limit = mem_limit or self.mem_limit
-        self.cpu_limit = float(cpu_limit) if cpu_limit else self.cpu_limit
-        if self.cpu_limit:
-            self.extra_host_config = {
-                "cpu_period": CPU_PERIOD,
-                "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
+class R2DSpawnerMixin(Configurable):
+    """
+    Mixin for spawners that derive from DockerSpawner, to use local Docker images
+    built with tljh-repo2docker.
+
+    Call `set_limits` in the spawner `start` method to set the memory and cpu limits.
+    """
+
+    image_form_template = Unicode(
+        """
+        <style>
+            #image-list {
+                max-height: 600px;
+                overflow: auto;
             }
+            .image-info {
+                font-weight: normal;
+            }
+        </style>
+        <div class='form-group' id='image-list'>
+        {% for image in image_list %}
+        <label for='image-item-{{ loop.index0 }}' class='form-control input-group'>
+            <div class='col-md-1'>
+                <input type='radio' name='image' id='image-item-{{ loop.index0 }}' value='{{ image.image_name }}' />
+                <input type='hidden' name='display_name' value='{{ image.display_name }}' />
+            </div>
+            <div class='col-md-11'>
+                <strong>{{ image.display_name }}</strong>
+                <div class='row image-info'>
+                    <div class='col-md-4'>
+                        Repository:
+                    </div>
+                    <div class='col-md-8'>
+                        <a href="{{ image.repo }}" target="_blank">{{ image.repo }}</a>
+                    </div>
+                </div>
+                <div class='row image-info'>
+                    <div class='col-md-4'>
+                        Reference:
+                    </div>
+                    <div class='col-md-8'>
+                        <a href="{{ image.repo }}/tree/{{ image.ref }}" target="_blank">{{ image.ref }}</a>
+                    </div>
+                </div>
+                <div class='row image-info'>
+                    <div class='col-md-4'>
+                        Memory Limit (GB):
+                    </div>
+                    <div class='col-md-8'>
+                        <strong>{{ image.mem_limit | replace("G", "") }}</strong>
+                    </div>
+                </div>
+                <div class='row image-info'>
+                    <div class='col-md-4'>
+                        CPU Limit:
+                    </div>
+                    <div class='col-md-8'>
+                        <strong>{{ image.cpu_limit }}</strong>
+                    </div>
+                </div>
+            </div>
+        </label>
+        {% endfor %}
+        </div>
+        """,
+        config=True,
+        help="""
+        Jinja2 template for constructing the list of images shown to the user.
+        """
+    )
 
     def image_whitelist(self, spawner):
         """
@@ -40,23 +99,45 @@ class TLJHDockerSpawner(DockerSpawner):
         Override the default form to handle the case when there is only one image.
         """
         images = list_images()
-        option_t = '<option value="{image_name}" {selected}>{display_name}</option>'
-        options = [
-            option_t.format(
-                image_name=image["image_name"],
-                display_name=image["display_name"],
-                selected="selected" if image["image_name"] == self.image else "",
-            )
-            for image in images
-        ]
-        return """
-        <label for="image">Select an image:</label>
-        <select class="form-control" name="image" required autofocus>
-        {options}
-        </select>
-        """.format(
-            options=options
-        )
+        # add memory and cpu limits
+        for image in images:
+            image['mem_limit'] = image['mem_limit'] or spawner.mem_limit
+            image['cpu_limit'] = image['cpu_limit'] or spawner.cpu_limit
+
+        image_form_template = Environment(loader=BaseLoader).from_string(self.image_form_template)
+        return image_form_template.render(image_list=images)
+
+    def options_from_form(self, formdata):
+        default_options = super().options_from_form(formdata)
+        default_options['display_name'] = formdata['display_name'][0]
+        return default_options
+
+    def set_limits(self):
+        """
+        Set the user environment limits if they are defined in the image
+        """
+        imagename = self.user_options.get("image")
+        image = client.images.get(imagename)
+        mem_limit = image.labels.get("tljh_repo2docker.mem_limit", None)
+        cpu_limit = image.labels.get("tljh_repo2docker.cpu_limit", None)
+
+        # override the spawner limits if defined in the image
+        if mem_limit:
+            self.mem_limit = mem_limit
+        if cpu_limit:
+            self.cpu_limit = float(cpu_limit)
+
+        if self.cpu_limit:
+            self.extra_host_config = {
+                "cpu_period": CPU_PERIOD,
+                "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
+            }
+
+
+class R2DSpawner(R2DSpawnerMixin, DockerSpawner):
+    """
+    A custom spawner for using local Docker images built with tljh-repo2docker.
+    """
 
     def start(self, *args, **kwargs):
         self.set_limits()
@@ -68,7 +149,7 @@ def tljh_custom_jupyterhub_config(c):
     # hub
     c.JupyterHub.hub_ip = public_ips()[0]
     c.JupyterHub.cleanup_servers = False
-    c.JupyterHub.spawner_class = TLJHDockerSpawner
+    c.JupyterHub.spawner_class = R2DSpawner
 
     # add extra templates for the service UI
     c.JupyterHub.template_paths.insert(
@@ -76,8 +157,8 @@ def tljh_custom_jupyterhub_config(c):
     )
 
     # spawner
-    c.TLJHDockerSpawner.cmd = ["jupyterhub-singleuser"]
-    c.TLJHDockerSpawner.pull_policy = "Never"
+    c.DockerSpawner.cmd = ["jupyterhub-singleuser"]
+    c.DockerSpawner.pull_policy = "Never"
 
     # fetch limits from the TLJH config
     tljh_config = load_config()

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -100,6 +100,9 @@ class SpawnerMixin(Configurable):
     )
 
     def options_from_form(self, formdata):
+        """
+        Add additional image information to the user options.
+        """
         default_options = super().options_from_form(formdata)
         default_options['display_name'] = formdata['display_name'][0]
         return default_options

--- a/tljh_repo2docker/builder.py
+++ b/tljh_repo2docker/builder.py
@@ -33,7 +33,6 @@ def build_image(repo, ref, name="", memory=None, cpu=None):
     # and sanitize the name of the docker image
     name = name or urlparse(repo).path.strip("/")
     name = name.replace("/", "-")
-    display_name = f"{name}-{ref}"
     image_name = f"{name}:{ref}"
 
     # memory is specified in GB
@@ -42,7 +41,7 @@ def build_image(repo, ref, name="", memory=None, cpu=None):
 
     # add extra labels to set additional image properties
     labels = [
-        f"LABEL tljh_repo2docker.display_name={display_name}",
+        f"LABEL tljh_repo2docker.display_name={name}",
         f"LABEL tljh_repo2docker.image_name={image_name}",
         f"LABEL tljh_repo2docker.mem_limit={memory}",
         f"LABEL tljh_repo2docker.cpu_limit={cpu}",
@@ -69,7 +68,7 @@ def build_image(repo, ref, name="", memory=None, cpu=None):
             "repo2docker.repo": repo,
             "repo2docker.ref": ref,
             "repo2docker.build": image_name,
-            "tljh_repo2docker.display_name": display_name,
+            "tljh_repo2docker.display_name": name,
             "tljh_repo2docker.mem_limit": memory,
             "tljh_repo2docker.cpu_limit": cpu,
         },
@@ -136,7 +135,7 @@ class BuildHandler(HubAuthenticated, web.RequestHandler):
         data = escape.json_decode(self.request.body)
         repo = data["repo"]
         ref = data["ref"]
-        name = data["name"]
+        name = data["name"].lower()
         memory = data["memory"]
         cpu = data["cpu"]
 

--- a/tljh_repo2docker/images.py
+++ b/tljh_repo2docker/images.py
@@ -57,7 +57,7 @@ def list_images():
             "status": "built",
         }
         for image in r2d_images
-        if "tljh_repo2docker.display_name" in image.labels
+        if "tljh_repo2docker.image_name" in image.labels
     ]
     return images
 

--- a/tljh_repo2docker/static/js/images.js
+++ b/tljh_repo2docker/static/js/images.js
@@ -26,7 +26,7 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function(
     var dialog = $("#create-environment-dialog");
     dialog.find(".repo-input").val("");
     dialog.find(".ref-input").val("");
-    dialog.find(".display-name-input").val("");
+    dialog.find(".name-input").val("");
     dialog.find(".memory-input").val("");
     dialog.find(".cpu-input").val("");
     dialog.modal();
@@ -36,9 +36,9 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function(
     .find(".save-button")
     .click(function() {
       var dialog = $("#create-environment-dialog");
-      var repo = dialog.find(".repo-input").val();
+      var repo = dialog.find(".repo-input").val().trim();
       var ref = dialog.find(".ref-input").val().trim();
-      var displayName = dialog.find(".display-name-input").val().trim();
+      var name = dialog.find(".name-input").val().trim();
       var memory = dialog.find(".memory-input").val().trim();
       var cpu = dialog.find(".cpu-input").val().trim();
       var spinner = $("#adding-environment-dialog");
@@ -49,7 +49,7 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function(
         data: JSON.stringify({
           repo: repo,
           ref: ref,
-          displayName: displayName,
+          name: name,
           memory: memory,
           cpu: cpu
         }),
@@ -64,10 +64,10 @@ require(["jquery", "bootstrap", "moment", "jhapi", "utils"], function(
     var el = $(this);
     var row = getRow(el);
     var image = row.data("image");
-    var displayName = row.data("display-name");
+    var name = row.data("display-name");
     var dialog = $("#remove-environment-dialog");
     dialog.find(".delete-environment").attr("data-image", image);
-    dialog.find(".delete-environment").text(displayName);
+    dialog.find(".delete-environment").text(name);
     dialog.modal();
   });
 

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -106,9 +106,9 @@
     <div class="form-group">
       <label for="name" class="col-sm-4 control-label">Name of the environment</label>
       <div class="col-sm-8">
-        <input data-toggle="tooltip" title="Allowed characters are a to z, 0 to 9, - and _"
+        <input data-toggle="tooltip" title="Allowed characters are a to z, A to Z, 0 to 9, - and _"
                type="text" class="form-control name-input" id="name"/>
-        <p class="help-block">Example: Course-Python-101-B37</p>
+        <p class="help-block">Example: course-python-101-B37</p>
       </div>
     </div>
     <div class="form-group">

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -109,6 +109,7 @@
         <input data-toggle="tooltip" title="Allowed characters are a to z, A to Z, 0 to 9, - and _"
                type="text" class="form-control name-input" id="name"/>
         <p class="help-block">Example: course-python-101-B37</p>
+        <p class="help-block">If empty, a name will be generated from the repo URL</p>
       </div>
     </div>
     <div class="form-group">

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -104,10 +104,10 @@
       </div>
     </div>
     <div class="form-group">
-      <label for="display_name" class="col-sm-4 control-label">Name of the environment</label>
+      <label for="name" class="col-sm-4 control-label">Name of the environment</label>
       <div class="col-sm-8">
-        <input data-toggle="tooltip" title="Allowed characters are A to Z, a to z, 0 to 9, - and _"
-               type="text" class="form-control display-name-input" id="display_name"/>
+        <input data-toggle="tooltip" title="Allowed characters are a to z, 0 to 9, - and _"
+               type="text" class="form-control name-input" id="name"/>
         <p class="help-block">Example: Course-Python-101-B37</p>
       </div>
     </div>


### PR DESCRIPTION
A couple of improvements on the environment naming and selection UI on the spawner options page.

Also fixes #9. 

### Changes

- Show more information about the environments on the spawner options page
- Lowercase environment names
- Docker image name follows
- Run docker commands in an executor

![image](https://user-images.githubusercontent.com/591645/80948819-25dc8600-8df3-11ea-9c44-404e41a9b0fa.png)