### PR TITLE
Lowercase the autogenerated name from the repo

### DIFF
--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -21,7 +21,7 @@ async def test_images_list_not_admin(app):
 
 
 @pytest.mark.asyncio
-async def test_spawn_page(app, remove_test_image, minimal_repo, image_name):
+async def test_spawn_page(app, minimal_repo, image_name):
     cookies = await app.login_user('admin')
 
     # go to the spawn page

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -21,7 +21,7 @@ def next_event(it):
 
 
 @pytest.mark.asyncio
-async def test_stream_simple(app, remove_test_image, minimal_repo, image_name):
+async def test_stream_simple(app, minimal_repo, image_name):
     name, ref = image_name.split(":")
     await add_environment(app, repo=minimal_repo, name=name, ref=ref)
     r = await api_request(app, "environments", image_name, "logs", stream=True)
@@ -38,7 +38,7 @@ async def test_stream_simple(app, remove_test_image, minimal_repo, image_name):
 
 
 @pytest.mark.asyncio
-async def test_no_build(app, remove_test_image, image_name, request):
+async def test_no_build(app, image_name, request):
     r = await api_request(app, "environments", "image-not-found:12345", "logs", stream=True)
     request.addfinalizer(r.close)
     assert r.status_code == 404

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ from jupyterhub.tests.utils import api_request
 
 
 async def add_environment(
-    app, *, repo, ref="master", name="tljh-repo2docker-test", memory="", cpu=""
+    app, *, repo, ref="master", name="", memory="", cpu=""
 ):
     """Use the POST endpoint to add a new environment"""
     r = await api_request(
@@ -24,18 +24,16 @@ async def wait_for_image(*, image_name):
     """wait until an image is built"""
     count, retries = 0, 60 * 10
     image = None
-    docker = Docker()
-    while count < retries:
-        await asyncio.sleep(1)
-        try:
-            image = await docker.images.inspect(image_name)
-        except DockerError:
-            count += 1
-            continue
-        else:
-            break
-
-    await docker.close()
+    async with Docker() as docker:
+        while count < retries:
+            await asyncio.sleep(1)
+            try:
+                image = await docker.images.inspect(image_name)
+            except DockerError:
+                count += 1
+                continue
+            else:
+                break
     return image
 
 

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -65,7 +65,7 @@ async def build_image(repo, ref, name="", memory=None, cpu=None):
     # default to the repo name if no name specified
     # and sanitize the name of the docker image
     name = name or urlparse(repo).path.strip("/")
-    name = name.replace("/", "-")
+    name = name.lower().replace("/", "-")
     image_name = f"{name}:{ref}"
 
     # memory is specified in GB


### PR DESCRIPTION
Fix for https://github.com/plasmabio/tljh-repo2docker/pull/22#issuecomment-633605549.

The name generated from the repository is now lowercased.

At some point we could also check what repo2docker does to generate valid Docker image names, and replicate or reuse the same logic.