### PR TITLE
Hide 'Cancel' button from logs window

### DIFF
--- a/tljh_repo2docker/static/css/style.css
+++ b/tljh_repo2docker/static/css/style.css
@@ -13,3 +13,7 @@
 .table > tbody > tr > td > p {
   margin: unset;
 }
+
+#show-logs-dialog .btn-default {
+  display: none;
+}


### PR DESCRIPTION
Hide the 'Cancel' button in the window that shows logs.

This button was misleading (it will not cancel the actual process of environment creation) and was redundant with the `Close` button.