### PR TITLE
Persistent user data storage

### DIFF
--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -148,10 +148,10 @@ class SpawnerMixin(Configurable):
             self.cpu_limit = float(cpu_limit)
 
         if self.cpu_limit:
-            self.extra_host_config = {
+            self.extra_host_config.update({
                 "cpu_period": CPU_PERIOD,
                 "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
-            }
+            })
 
 
 class Repo2DockerSpawner(SpawnerMixin, DockerSpawner):

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -25,8 +25,32 @@ async def list_images():
         }
         for image in r2d_images
         if "tljh_repo2docker.image_name" in image["Labels"]
+            and "tljh_repo2docker.storage_for" not in image["Labels"]
     ]
     return images
+
+
+async def find_storage(imagename=None):
+    """
+    Find appropiate storage image name for imagename
+    """
+    async with Docker() as docker:
+        images = None if not imagename else await docker.images.list(
+            filters=json.dumps({
+                "dangling": ["false"],
+                "label": ["tljh_repo2docker.storage_for=" + imagename]
+            })
+        )
+        images = images if images else await docker.images.list(
+            filters=json.dumps({
+                "dangling": ["false"],
+                "label": ["tljh_repo2docker.storage_for=ALL"]
+            })
+        )
+    result = images[0] if images else None
+    if not result:
+        return None
+    return result["Id"]
 
 
 async def list_containers():


### PR DESCRIPTION
Depends on #34

This, on container start, checks for the new label "tljh_repo2docker.storage_for" on any existing image, which has to be set to either ALL or the name of the image currently being started.
If it matches, it creates a new container from that image, and sets it as volumes_from for the container about to be created/started.

If a container with the right name(normally "storage-$USERNAME") already exists, it is used as volume source and no new one is created.

The image used to create the storage container has to have volumes setup in such a way that they match users and permissions of the container it's being used in.
The easiest way for that is to base it on the r2d image itself:

```
FROM our-r2d:master
LABEL tljh_repo2docker.storage_for=our-r2d:master
VOLUME /home/jovyan
```

Building an image from a Dockerfile like that on the system is enough to get it picked up.


Update: This has some unforseen side effects which I'm not fully sure what's causing them yet, so putting this as draft for the moment.