### PR TITLE
Await rendered template if neccesary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        jupyterhub-version: [latest, 1.2.2]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,9 +29,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         python -m pip install -r dev-requirements.txt
         python -m pip install -e .
+    - name: Downgrade jupyterhub
+      if: ${{ matrix.jupyterhub-version != 'latest' }}
+      run: |
+        python -m pip install -U 'jupyterhub==${{ matrix.jupyterhub-version }}'
     - name: Run Tests
       run: |
         python -m pytest --cov

--- a/tljh_repo2docker/images.py
+++ b/tljh_repo2docker/images.py
@@ -1,3 +1,4 @@
+from inspect import isawaitable
 from jupyterhub.handlers.base import BaseHandler
 from jupyterhub.utils import admin_only
 from tornado import web
@@ -15,11 +16,13 @@ class ImagesHandler(BaseHandler):
     async def get(self):
         images = await list_images()
         containers = await list_containers()
-        self.write(
-            self.render_template(
-                "images.html",
-                images=images + containers,
-                default_mem_limit=self.settings.get("default_mem_limit"),
-                default_cpu_limit=self.settings.get("default_cpu_limit"),
-            )
+        result = self.render_template(
+            "images.html",
+            images=images + containers,
+            default_mem_limit=self.settings.get("default_mem_limit"),
+            default_cpu_limit=self.settings.get("default_cpu_limit"),
         )
+        if isawaitable(result):
+            self.write(await result)
+        else:
+            self.write(result)


### PR DESCRIPTION
Latest release of jupyterhub made render_template return a coroutine: https://github.com/jupyterhub/jupyterhub/commit/be211a48ef194d1c478dcef2f5afa1bfc9f40541

So it needs to be awaited now, or else self.write throws an error.
To keep backwards compatibility, I first check of the result is indeed awaitable.
Could also just drop this check and always await it, if assuming the use of the latest version of jupyterhub is fine.