### PR TITLE
Pin dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_repo2docker = tljh_repo2docker"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner", "jupyter_client", "aiodocker"],
+    install_requires=["dockerspawner~=0.11", "jupyter_client~=6.1", "aiodocker~=0.19"],
 )

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -181,6 +181,7 @@ def tljh_custom_jupyterhub_config(c):
     # spawner
     c.DockerSpawner.cmd = ["jupyterhub-singleuser"]
     c.DockerSpawner.pull_policy = "Never"
+    c.DockerSpawner.remove = True
 
     # fetch limits from the TLJH config
     tljh_config = load_config()

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -148,10 +148,12 @@ class SpawnerMixin(Configurable):
             self.cpu_limit = float(cpu_limit)
 
         if self.cpu_limit:
-            self.extra_host_config.update({
-                "cpu_period": CPU_PERIOD,
-                "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
-            })
+            self.extra_host_config.update(
+                {
+                    "cpu_period": CPU_PERIOD,
+                    "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
+                }
+            )
 
 
 class Repo2DockerSpawner(SpawnerMixin, DockerSpawner):
@@ -207,4 +209,4 @@ def tljh_custom_jupyterhub_config(c):
 
 @hookimpl
 def tljh_extra_hub_pip_packages():
-    return ["dockerspawner", "jupyter_client"]
+    return ["dockerspawner~=0.11", "jupyter_client~=6.1", "aiodocker~=0.19"]


### PR DESCRIPTION
Better pin some of the dependencies of `tljh-repo2docker` to have more control on potential breaking changes.

And set `c.DockerSpawner.remove = True` by default to remove previously stopped containers.