### PR TITLE
Add support for GIT_CREDENTIAL_ENV to build private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Once ready, the environments can be selected from the JupyterHub spawn page:
 
 ![select-env](https://user-images.githubusercontent.com/591645/81152248-10e22d00-8f82-11ea-9b5f-5831d8f7d085.png)
 
+### Private Repositories
+
+`tljh-repo2docker` also supports building environments from private repositories.
+
+It is possible to provide the `username` and `password` in the `Credentials` section of the form:
+
+![image](https://user-images.githubusercontent.com/591645/107355189-6d551880-6acf-11eb-8b52-b4b154e04fd6.png)
+
+On GitHub and GitLab, a user might have to first create an access token with `read` access to use as the password:
+
+![image](https://user-images.githubusercontent.com/591645/107350843-39c3bf80-6aca-11eb-8b82-6fa95ba4c7e4.png)
+
 ### Extra documentation
 
 `tljh-repo2docker` is currently developed as part of the [Plasma project](https://github.com/plasmabio/plasma).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Once ready, the environments can be selected from the JupyterHub spawn page:
 
 It is possible to provide the `username` and `password` in the `Credentials` section of the form:
 
-![image](https://user-images.githubusercontent.com/591645/107355189-6d551880-6acf-11eb-8b52-b4b154e04fd6.png)
+![image](https://user-images.githubusercontent.com/591645/107362654-51567480-6ad9-11eb-93be-74d3b1c37828.png)
 
 On GitHub and GitLab, a user might have to first create an access token with `read` access to use as the password:
 

--- a/tljh_repo2docker/builder.py
+++ b/tljh_repo2docker/builder.py
@@ -39,6 +39,8 @@ class BuildHandler(APIHandler):
         name = data["name"].lower()
         memory = data["memory"]
         cpu = data["cpu"]
+        username = data["username"]
+        password = data["password"]
 
         if not repo:
             raise web.HTTPError(400, "Repository is empty")
@@ -61,7 +63,7 @@ class BuildHandler(APIHandler):
                 f"The name of the environment is restricted to the following characters: {IMAGE_NAME_RE}",
             )
 
-        await build_image(repo, ref, name, memory, cpu)
+        await build_image(repo, ref, name, memory, cpu, username, password)
 
         self.set_status(200)
         self.finish(json.dumps({"status": "ok"}))

--- a/tljh_repo2docker/builder.py
+++ b/tljh_repo2docker/builder.py
@@ -39,8 +39,8 @@ class BuildHandler(APIHandler):
         name = data["name"].lower()
         memory = data["memory"]
         cpu = data["cpu"]
-        username = data["username"]
-        password = data["password"]
+        username = data.get("username", None)
+        password = data.get("password", None)
 
         if not repo:
             raise web.HTTPError(400, "Repository is empty")

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -97,7 +97,7 @@ async def build_image(
         repo,
     ]
 
-    config={
+    config = {
         "Cmd": cmd,
         "Image": "jupyter/repo2docker:master",
         "Labels": {
@@ -124,9 +124,11 @@ async def build_image(
     }
 
     if username and password:
-        config.update({
-            "Env": [f"GIT_CREDENTIAL_ENV=username={username}\npassword={password}"],
-        })
+        config.update(
+            {
+                "Env": [f"GIT_CREDENTIAL_ENV=username={username}\npassword={password}"],
+            }
+        )
 
     async with Docker() as docker:
         await docker.containers.run(config=config)

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -54,7 +54,9 @@ async def list_containers():
     return containers
 
 
-async def build_image(repo, ref, name="", memory=None, cpu=None):
+async def build_image(
+    repo, ref, name="", memory=None, cpu=None, username=None, password=None
+):
     """
     Build an image given a repo, ref and limits
     """
@@ -94,26 +96,37 @@ async def build_image(repo, ref, name="", memory=None, cpu=None):
         "\n".join(labels),
         repo,
     ]
-    async with Docker() as docker:
-        await docker.containers.run(
-            config={
-                "Cmd": cmd,
-                "Image": "jupyter/repo2docker:master",
-                "Labels": {
-                    "repo2docker.repo": repo,
-                    "repo2docker.ref": ref,
-                    "repo2docker.build": image_name,
-                    "tljh_repo2docker.display_name": name,
-                    "tljh_repo2docker.mem_limit": memory,
-                    "tljh_repo2docker.cpu_limit": cpu,
-                },
-                "Volumes": {
-                    "/var/run/docker.sock": {"bind": "/var/run/docker.sock", "mode": "rw",}
-                },
-                "HostConfig": {"Binds": ["/var/run/docker.sock:/var/run/docker.sock"],},
-                "Tty": False,
-                "AttachStdout": False,
-                "AttachStderr": False,
-                "OpenStdin": False,
+
+    config={
+        "Cmd": cmd,
+        "Image": "jupyter/repo2docker:master",
+        "Labels": {
+            "repo2docker.repo": repo,
+            "repo2docker.ref": ref,
+            "repo2docker.build": image_name,
+            "tljh_repo2docker.display_name": name,
+            "tljh_repo2docker.mem_limit": memory,
+            "tljh_repo2docker.cpu_limit": cpu,
+        },
+        "Volumes": {
+            "/var/run/docker.sock": {
+                "bind": "/var/run/docker.sock",
+                "mode": "rw",
             }
-        )
+        },
+        "HostConfig": {
+            "Binds": ["/var/run/docker.sock:/var/run/docker.sock"],
+        },
+        "Tty": False,
+        "AttachStdout": False,
+        "AttachStderr": False,
+        "OpenStdin": False,
+    }
+
+    if username and password:
+        config.update({
+            "Env": [f"GIT_CREDENTIAL_ENV=username={username}\npassword={password}"],
+        })
+
+    async with Docker() as docker:
+        await docker.containers.run(config=config)

--- a/tljh_repo2docker/static/css/style.css
+++ b/tljh_repo2docker/static/css/style.css
@@ -19,8 +19,6 @@
 }
 
 details {
-  border: 1px solid #aaa;
-  border-radius: 4px;
   padding: 0.5em 0.5em 0;
 }
 
@@ -36,6 +34,5 @@ details[open] {
 }
 
 details[open] summary {
-  border-bottom: 1px solid #aaa;
   margin-bottom: 0.5em;
 }

--- a/tljh_repo2docker/static/css/style.css
+++ b/tljh_repo2docker/static/css/style.css
@@ -17,3 +17,25 @@
 #show-logs-dialog .btn-default {
   display: none;
 }
+
+details {
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  padding: 0.5em 0.5em 0;
+}
+
+summary {
+  font-weight: bold;
+  margin: -0.5em -0.5em 0;
+  padding: 0.5em;
+  cursor: pointer;
+}
+
+details[open] {
+  padding: 0.5em;
+}
+
+details[open] summary {
+  border-bottom: 1px solid #aaa;
+  margin-bottom: 0.5em;
+}

--- a/tljh_repo2docker/static/js/images.js
+++ b/tljh_repo2docker/static/js/images.js
@@ -36,6 +36,8 @@ require([
     dialog.find(".name-input").val("");
     dialog.find(".memory-input").val("");
     dialog.find(".cpu-input").val("");
+    dialog.find(".username-input").val("");
+    dialog.find(".password-input").val("");
     dialog.modal();
   });
 
@@ -48,6 +50,8 @@ require([
       var name = dialog.find(".name-input").val().trim();
       var memory = dialog.find(".memory-input").val().trim();
       var cpu = dialog.find(".cpu-input").val().trim();
+      var username = dialog.find(".username-input").val().trim();
+      var password = dialog.find(".password-input").val().trim();
       var spinner = $("#adding-environment-dialog");
       spinner.find('.modal-footer').remove();
       spinner.modal();
@@ -58,7 +62,9 @@ require([
           ref: ref,
           name: name,
           memory: memory,
-          cpu: cpu
+          cpu: cpu,
+          username: username,
+          password: password,
         }),
         success: function() {
           window.location.reload();

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -130,18 +130,21 @@
         <input type="number" step="1" min="1" class="form-control cpu-input" id="cpu" placeholder="2"/>
       </div>
     </div>
-    <div class="form-group">
-      <label for="username" class="col-sm-4 control-label">Git Username</label>
-      <div class="col-sm-8">
-        <input type="text" class="form-control username-input" id="username"/>
+    <details>
+      <summary>˃ Credentials (optional)</summary>
+      <div class="form-group">
+        <label for="username" class="col-sm-4 control-label">Git Username</label>
+        <div class="col-sm-8">
+          <input type="text" class="form-control username-input" id="username"/>
+        </div>
       </div>
-    </div>
-    <div class="form-group">
-      <label for="password" class="col-sm-4 control-label">Git Password</label>
-      <div class="col-sm-8">
-        <input type="password" class="form-control password-input" id="password"/>
+      <div class="form-group">
+        <label for="password" class="col-sm-4 control-label">Git Password</label>
+        <div class="col-sm-8">
+          <input type="password" class="form-control password-input" id="password"/>
+        </div>
       </div>
-    </div>
+    </details>
   </div>
 {% endcall %}
 {% endmacro %}

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -130,6 +130,18 @@
         <input type="number" step="1" min="1" class="form-control cpu-input" id="cpu" placeholder="2"/>
       </div>
     </div>
+    <div class="form-group">
+      <label for="username" class="col-sm-4 control-label">Git Username</label>
+      <div class="col-sm-8">
+        <input type="text" class="form-control username-input" id="username"/>
+      </div>
+    </div>
+    <div class="form-group">
+      <label for="password" class="col-sm-4 control-label">Git Password</label>
+      <div class="col-sm-8">
+        <input type="password" class="form-control password-input" id="password"/>
+      </div>
+    </div>
   </div>
 {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Fixes #27 

This makes it possible to pass a `username` and `password` from the UI:

https://user-images.githubusercontent.com/591645/107351297-bbb3e880-6aca-11eb-9a78-8e4e843260d4.mp4


Using `repo2docker` support for `GIT_CREDENTIAL_ENV` (some info in https://github.com/jupyterhub/repo2docker/commit/504aeb7300dce5ee3bd6aaf9a836f96855b435b6)

For example with GitHub, a user can generate a new access token with the `read` scope:

![image](https://user-images.githubusercontent.com/591645/107350843-39c3bf80-6aca-11eb-8b82-6fa95ba4c7e4.png)

And use this token as the password.

Similar with GitLab:

![image](https://user-images.githubusercontent.com/591645/107350897-46e0ae80-6aca-11eb-860f-b99fd3611bd7.png)
