### PR TITLE
Update repo2docker image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ Check out the official Docker documentation to know how to install Docker on you
 
 ## Create a virtual environment
 
-Using `conda`:
+Using `mamba` / `conda`:
 
 ```bash
-conda create -n tljh-repo2docker -c conda-forge python nodejs
+mamba create -n tljh-repo2docker -c conda-forge python nodejs
 conda activate tljh-repo2docker
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ npm -g install configurable-http-proxy
 User environments are built with `repo2docker` running in a Docker container. To pull the Docker image:
 
 ```bash
-docker pull jupyter/repo2docker:master
+docker pull quay.io/jupyterhub/repo2docker:main
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/u
 sudo apt update && sudo apt install -y docker-ce
 
 # pull the repo2docker image
-sudo docker pull jupyter/repo2docker:master
+sudo docker pull quay.io/jupyterhub/repo2docker:main
 
 # install TLJH
 curl https://raw.githubusercontent.com/jupyterhub/the-littlest-jupyterhub/master/bootstrap/bootstrap.py \

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -99,7 +99,7 @@ async def build_image(
 
     config = {
         "Cmd": cmd,
-        "Image": "jupyter/repo2docker:master",
+        "Image": "quay.io/jupyterhub/repo2docker:main",
         "Labels": {
             "repo2docker.repo": repo,
             "repo2docker.ref": ref,


### PR DESCRIPTION
The `jupyter/repo2docker` image is not published to Dockerhub anymore:

https://hub.docker.com/r/jupyter/repo2docker

![image](https://user-images.githubusercontent.com/591645/144385083-60097765-4944-42b1-adc6-302e45d14303.png)
