### PR TITLE
Pin to `jupyterhub~=1.5` for development, update `dockerspawner`, default ref to `HEAD`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
-       node-version: '10.x'
+       node-version: '14.x'
     - name: Install configurable-http-proxy
       run: npm -g install configurable-http-proxy
     - name: Set up Python ${{ matrix.python-version }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
+jupyterhub~=1.5
 notebook
 pytest
 pytest-aiohttp

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_repo2docker = tljh_repo2docker"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=0.11", "jupyter_client~=6.1", "aiodocker~=0.19"],
+    install_requires=["dockerspawner~=12.1", "jupyter_client~=6.1", "aiodocker~=0.19"],
 )

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -60,7 +60,7 @@ async def build_image(
     """
     Build an image given a repo, ref and limits
     """
-    ref = ref or "master"
+    ref = ref or "HEAD"
     if len(ref) >= 40:
         ref = ref[:7]
 

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -106,7 +106,7 @@
     <div class="form-group">
       <label for="reference" class="col-sm-4 control-label">Reference (git commit)</label>
       <div class="col-sm-8">
-        <input type="text" class="form-control ref-input" id="reference" placeholder="master"/>
+        <input type="text" class="form-control ref-input" id="reference" placeholder="HEAD"/>
       </div>
     </div>
     <div class="form-group">

--- a/tljh_repo2docker/tests/conftest.py
+++ b/tljh_repo2docker/tests/conftest.py
@@ -42,12 +42,12 @@ def minimal_repo_uppercase():
 
 @pytest.fixture(scope='module')
 def generated_image_name():
-    return "jtpio-test-binder:master"
+    return "jtpio-test-binder:HEAD"
 
 
 @pytest.fixture(scope='module')
 def image_name():
-    return "tljh-repo2docker-test:master"
+    return "tljh-repo2docker-test:HEAD"
 
 
 @pytest.fixture(scope='module')

--- a/tljh_repo2docker/tests/utils.py
+++ b/tljh_repo2docker/tests/utils.py
@@ -6,7 +6,7 @@ from jupyterhub.tests.utils import api_request
 
 
 async def add_environment(
-    app, *, repo, ref="master", name="", memory="", cpu=""
+    app, *, repo, ref="HEAD", name="", memory="", cpu=""
 ):
     """Use the POST endpoint to add a new environment"""
     r = await api_request(


### PR DESCRIPTION
JupyterHub 2.0 was released yesterday: https://blog.jupyter.org/jupyterhub-2-0-7a038715e96d

But TLJH still installs `jupyterhub==1.*` for now:

https://github.com/jupyterhub/the-littlest-jupyterhub/blob/ad38fad96afe8096e722279da095a0633b5d2c6b/tljh/installer.py#L124

This avoids picking up the new version for now, so they upgrade to 2.0 can be done explicitly.

Other updates:

- [x] Update to `dockerspawner~=12.1`
- [x] Update node on CI
- [x] Update default ref to `HEAD`. Fixes #43.