### PR TITLE
Update Python versions on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.8", "3.9", "3.10"]
         jupyterhub-version: [latest, 1.2.2]
 
     steps:


### PR DESCRIPTION
Update to newer versions of Python on CI.

Since we support Ubuntu 20.04+ which ships with Python 3.8.