### PR TITLE
Expose custom build-args as advanced option in the UI

### DIFF
--- a/tljh_repo2docker/builder.py
+++ b/tljh_repo2docker/builder.py
@@ -39,6 +39,7 @@ class BuildHandler(APIHandler):
         name = data["name"].lower()
         memory = data["memory"]
         cpu = data["cpu"]
+        buildargs = data.get("buildargs", None)
         username = data.get("username", None)
         password = data.get("password", None)
 
@@ -63,7 +64,17 @@ class BuildHandler(APIHandler):
                 f"The name of the environment is restricted to the following characters: {IMAGE_NAME_RE}",
             )
 
-        await build_image(repo, ref, name, memory, cpu, username, password)
+        extra_buildargs = []
+        if buildargs:
+            for barg in buildargs.split("\n"):
+                if "=" not in barg:
+                    raise web.HTTPError(
+                        400,
+                        "Invalid build argument format"
+                    )
+                extra_buildargs.append(barg)
+
+        await build_image(repo, ref, name, memory, cpu, username, password, extra_buildargs)
 
         self.set_status(200)
         self.finish(json.dumps({"status": "ok"}))

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -55,7 +55,8 @@ async def list_containers():
 
 
 async def build_image(
-    repo, ref, name="", memory=None, cpu=None, username=None, password=None
+    repo, ref, name="", memory=None, cpu=None, username=None, password=None,
+    extra_buildargs=None
 ):
     """
     Build an image given a repo, ref and limits
@@ -98,6 +99,12 @@ async def build_image(
         cmd += [
             "--label",
             label
+        ]
+
+    for barg in extra_buildargs or []:
+        cmd += [
+            "--build-arg",
+            barg
         ]
 
     cmd.append(repo)

--- a/tljh_repo2docker/static/js/images.js
+++ b/tljh_repo2docker/static/js/images.js
@@ -36,6 +36,7 @@ require([
     dialog.find(".name-input").val("");
     dialog.find(".memory-input").val("");
     dialog.find(".cpu-input").val("");
+    dialog.find(".build-args-input").val("");
     dialog.find(".username-input").val("");
     dialog.find(".password-input").val("");
     dialog.modal();
@@ -50,6 +51,7 @@ require([
       var name = dialog.find(".name-input").val().trim();
       var memory = dialog.find(".memory-input").val().trim();
       var cpu = dialog.find(".cpu-input").val().trim();
+      var buildargs = dialog.find(".build-args-input").val().trim();
       var username = dialog.find(".username-input").val().trim();
       var password = dialog.find(".password-input").val().trim();
       var spinner = $("#adding-environment-dialog");
@@ -63,6 +65,7 @@ require([
           name: name,
           memory: memory,
           cpu: cpu,
+          buildargs: buildargs,
           username: username,
           password: password,
         }),

--- a/tljh_repo2docker/templates/images.html
+++ b/tljh_repo2docker/templates/images.html
@@ -131,7 +131,16 @@
       </div>
     </div>
     <details>
-      <summary>˃ Credentials (optional)</summary>
+      <summary>&gt; Advanced</summary>
+      <div class="form-group">
+        <label for="build-args" class="col-sm-4 control-label">Build Arguments</label>
+        <div class="col-sm-8">
+          <textarea class="form-control build-args-input" id="build-args" rows="4" placeholder="arg1=val1&#10;arg2=val2&#10;..."></textarea>
+        </div>
+      </div>
+    </details>
+    <details>
+      <summary>&gt; Credentials (optional)</summary>
       <div class="form-group">
         <label for="username" class="col-sm-4 control-label">Git Username</label>
         <div class="col-sm-8">


### PR DESCRIPTION
After https://github.com/jupyterhub/repo2docker/pull/1100 got merged, it's now possible to pass custom build-args to the image build process.
This exposes that option to the user.

This PR sits on top of my other PR https://github.com/plasmabio/tljh-repo2docker/pull/48 because it has slight overlap. So that one needs to be merged first, and then this one probably needs a quick rebase.

![image](https://user-images.githubusercontent.com/16896306/147824761-d7c21413-3452-4375-8f15-1d9f86ab94b8.png)

![image](https://user-images.githubusercontent.com/16896306/147824766-f58f72a3-d0cf-4781-ba8c-fb741afe6cb2.png)
