### PR TITLE
Update test binder repo to the new URL

### DIFF
--- a/tljh_repo2docker/tests/conftest.py
+++ b/tljh_repo2docker/tests/conftest.py
@@ -32,17 +32,17 @@ async def remove_docker_image(image_name):
 
 @pytest.fixture(scope='module')
 def minimal_repo():
-    return "https://github.com/jtpio/test-binder"
+    return "https://github.com/plasmabio/test-binder"
 
 
 @pytest.fixture(scope='module')
 def minimal_repo_uppercase():
-    return "https://github.com/jtpio/TEST-BINDER"
+    return "https://github.com/plasmabio/TEST-BINDER"
 
 
 @pytest.fixture(scope='module')
 def generated_image_name():
-    return "jtpio-test-binder:HEAD"
+    return "plasmabio-test-binder:HEAD"
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
The `test-binder` repo used in the tests has been moved to https://github.com/plasmabio/test-binder for consistency and convenience.