### PR TITLE
Pin `notebook<7` and `sqlalchemy<2` for now

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub
 jupyterhub~=1.5
-notebook
+notebook<7
 pytest
 pytest-aiohttp
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(
     entry_points={"tljh": ["tljh_repo2docker = tljh_repo2docker"]},
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["dockerspawner~=12.1", "jupyter_client~=6.1", "aiodocker~=0.19"],
+    install_requires=["dockerspawner~=12.1", "jupyter_client~=6.1", "aiodocker~=0.19", "sqlalchemy<2"],
 )


### PR DESCRIPTION
Investigate the CI failure noticed in https://github.com/plasmabio/tljh-repo2docker/pull/61#issuecomment-1814057409