### PR TITLE
Start single server from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,13 @@ The available settings for this service are:
 - `default_cpu_limit`: Default CPU limit of a user server; defaults to `None`
 - `machine_profiles`: Instead of entering directly the CPU and Memory value, `tljh-repo2docker` can be configured with pre-defined machine profiles and users can only choose from the available option; defaults to `[]`
 
-Here is an example of registering `tljh_repo2docker`'s service with JupyterHub
+This service requires the following scopes : `read:users`, `admin:servers` and `read:roles:users`. Here is an example of registering `tljh_repo2docker`'s service with JupyterHub
 
 ```python
 # jupyterhub_config.py
 
 from tljh_repo2docker import TLJH_R2D_ADMIN_SCOPE
+import sys
 
 c.JupyterHub.services.extend(
     [
@@ -77,7 +78,7 @@ c.JupyterHub.load_roles = [
     {
         "description": "Role for tljh_repo2docker service",
         "name": "tljh-repo2docker-service",
-        "scopes": ["read:users", "read:servers", "read:roles:users"],
+        "scopes": ["read:users", "admin:servers", "read:roles:users"],
         "services": ["tljh_repo2docker"],
     },
     {
@@ -99,6 +100,7 @@ Here is an example of the configuration
 # jupyterhub_config.py
 
 from tljh_repo2docker import TLJH_R2D_ADMIN_SCOPE
+import sys
 
 c.JupyterHub.services.extend(
     [

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -14,6 +14,8 @@ apply_config(tljh_config, c)
 
 tljh_custom_jupyterhub_config(c)
 
+c.JupyterHub.default_url = '/services/tljh_repo2docker/'
+
 c.JupyterHub.authenticator_class = DummyAuthenticator
 
 c.JupyterHub.allow_named_servers = True

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -37,8 +37,7 @@ c.JupyterHub.services.extend(
                 "--machine_profiles",
                 '{"label": "Medium", "cpu": 4, "memory": 4}',
                 "--machine_profiles",
-                '{"label": "Large", "cpu": 8, "memory": 8}'
-
+                '{"label": "Large", "cpu": 8, "memory": 8}',
             ],
             "oauth_no_confirm": True,
             "oauth_client_allowed_scopes": [
@@ -58,11 +57,11 @@ c.JupyterHub.load_roles = [
     {
         "description": "Role for tljh_repo2docker service",
         "name": "tljh-repo2docker-service",
-        "scopes": ["read:users", "read:servers", "read:roles:users"],
+        "scopes": ["read:users", "read:servers", "read:roles:users", "admin:servers"],
         "services": ["tljh_repo2docker"],
     },
     {
-        "name": 'tljh-repo2docker-service-admin',
+        "name": "tljh-repo2docker-service-admin",
         "users": ["alice"],
         "scopes": [TLJH_R2D_ADMIN_SCOPE],
     },

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -58,7 +58,7 @@ c.JupyterHub.load_roles = [
     {
         "description": "Role for tljh_repo2docker service",
         "name": "tljh-repo2docker-service",
-        "scopes": ["read:users", "read:servers", "read:roles:users", "admin:servers"],
+        "scopes": ["read:users", "read:roles:users", "admin:servers"],
         "services": ["tljh_repo2docker"],
     },
     {

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -14,7 +14,6 @@ apply_config(tljh_config, c)
 
 tljh_custom_jupyterhub_config(c)
 
-c.JupyterHub.default_url = '/services/tljh_repo2docker/'
 
 c.JupyterHub.authenticator_class = DummyAuthenticator
 

--- a/src/common/AxiosContext.tsx
+++ b/src/common/AxiosContext.tsx
@@ -2,9 +2,8 @@ import { createContext, useContext } from 'react';
 import { AxiosClient } from './axiosclient';
 
 export const AxiosContext = createContext<{
-  hubClient: AxiosClient;
   serviceClient: AxiosClient;
-}>({ hubClient: new AxiosClient({}), serviceClient: new AxiosClient({}) });
+}>({ serviceClient: new AxiosClient({}) });
 
 export const useAxios = () => {
   return useContext(AxiosContext);

--- a/src/common/ButtonWithConfirm.tsx
+++ b/src/common/ButtonWithConfirm.tsx
@@ -3,9 +3,8 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import CircularProgress from '@mui/material/CircularProgress';
-import Box from '@mui/material/Box';
 import { Fragment, memo, useCallback, useState } from 'react';
+import { Loading } from './LoadingAnimation';
 
 interface IButtonWithConfirm {
   buttonLabel: string;
@@ -15,11 +14,7 @@ interface IButtonWithConfirm {
   okLabel?: string;
   cancelLabel?: string;
 }
-const Loading = () => (
-  <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-    <CircularProgress />
-  </Box>
-);
+
 function _ButtonWithConfirm(props: IButtonWithConfirm) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);

--- a/src/common/LoadingAnimation.tsx
+++ b/src/common/LoadingAnimation.tsx
@@ -1,0 +1,7 @@
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
+export const Loading = () => (
+  <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+    <CircularProgress />
+  </Box>
+);

--- a/src/common/axiosclient.ts
+++ b/src/common/axiosclient.ts
@@ -19,8 +19,9 @@ export class AxiosClient {
     path: string;
     query?: string;
     data?: { [key: string]: any } | FormData;
+    params?: { [key: string]: string };
   }): Promise<T> {
-    const { method, path } = args;
+    const { method, path, params } = args;
     const prefix = args.prefix ?? '';
     const data = args.data ?? {};
     let url = urlJoin(prefix, encodeUriComponents(path));
@@ -35,7 +36,8 @@ export class AxiosClient {
     const response = await this._axios.request<T>({
       method,
       url,
-      data
+      data,
+      params
     });
     return response.data;
   }

--- a/src/common/axiosclient.ts
+++ b/src/common/axiosclient.ts
@@ -2,8 +2,6 @@ import urlJoin from 'url-join';
 import { encodeUriComponents } from './utils';
 import axios, { AxiosInstance } from 'axios';
 
-export const API_PREFIX = 'api';
-export const SPAWN_PREFIX = 'spawn';
 export class AxiosClient {
   constructor(options: AxiosClient.IOptions) {
     this._baseUrl = options.baseUrl ?? '';
@@ -15,14 +13,13 @@ export class AxiosClient {
 
   async request<T = any>(args: {
     method: 'get' | 'post' | 'put' | 'option' | 'delete';
-    prefix?: 'api' | 'spawn';
     path: string;
     query?: string;
     data?: { [key: string]: any } | FormData;
     params?: { [key: string]: string };
   }): Promise<T> {
     const { method, path, params } = args;
-    const prefix = args.prefix ?? '';
+    const prefix = 'api';
     const data = args.data ?? {};
     let url = urlJoin(prefix, encodeUriComponents(path));
     if (args.query) {

--- a/src/common/axiosclient.ts
+++ b/src/common/axiosclient.ts
@@ -15,15 +15,15 @@ export class AxiosClient {
 
   async request<T = any>(args: {
     method: 'get' | 'post' | 'put' | 'option' | 'delete';
-    prefix: 'api' | 'spawn';
+    prefix?: 'api' | 'spawn';
     path: string;
     query?: string;
     data?: { [key: string]: any } | FormData;
   }): Promise<T> {
     const { method, path } = args;
-
+    const prefix = args.prefix ?? '';
     const data = args.data ?? {};
-    let url = urlJoin(args.prefix, encodeUriComponents(path));
+    let url = urlJoin(prefix, encodeUriComponents(path));
     if (args.query) {
       const sep = url.indexOf('?') === -1 ? '?' : '&';
       url = `${url}${sep}${args.query}`;

--- a/src/environments/App.tsx
+++ b/src/environments/App.tsx
@@ -20,12 +20,6 @@ export interface IAppProps {
 export default function App(props: IAppProps) {
   const jhData = useJupyterhub();
 
-  const hubClient = useMemo(() => {
-    const baseUrl = jhData.hubPrefix;
-    const xsrfToken = jhData.xsrfToken;
-    return new AxiosClient({ baseUrl, xsrfToken });
-  }, [jhData]);
-
   const serviceClient = useMemo(() => {
     const baseUrl = jhData.servicePrefix;
     const xsrfToken = jhData.xsrfToken;
@@ -34,7 +28,7 @@ export default function App(props: IAppProps) {
 
   return (
     <ThemeProvider theme={customTheme}>
-      <AxiosContext.Provider value={{ hubClient, serviceClient }}>
+      <AxiosContext.Provider value={{ serviceClient }}>
         <ScopedCssBaseline>
           <Stack sx={{ padding: 1 }} spacing={1}>
             <NewEnvironmentDialog

--- a/src/environments/EnvironmentList.tsx
+++ b/src/environments/EnvironmentList.tsx
@@ -91,6 +91,7 @@ export interface IEnvironmentListProps {
   selectable?: boolean;
   rowSelectionModel?: GridRowSelectionModel;
   setRowSelectionModel?: (selected: GridRowSelectionModel) => void;
+  loading?: boolean;
 }
 
 function _EnvironmentList(props: IEnvironmentListProps) {
@@ -111,6 +112,7 @@ function _EnvironmentList(props: IEnvironmentListProps) {
   return (
     <Box sx={{ padding: 1 }}>
       <DataGrid
+        loading={Boolean(props.loading)}
         rows={rows}
         columns={columns}
         initialState={{

--- a/src/environments/NewEnvironmentDialog.tsx
+++ b/src/environments/NewEnvironmentDialog.tsx
@@ -15,7 +15,6 @@ import {
 } from '@mui/material';
 import { Fragment, memo, useCallback, useMemo, useState } from 'react';
 
-import { API_PREFIX } from '../common/axiosclient';
 import { useAxios } from '../common/AxiosContext';
 import { SmallTextField } from '../common/SmallTextField';
 import { ENV_PREFIX } from './types';
@@ -174,7 +173,6 @@ function _NewEnvironmentDialog(props: INewEnvironmentDialogProps) {
             data.password = data.password ?? '';
             const response = await axios.serviceClient.request({
               method: 'post',
-              prefix: API_PREFIX,
               path: ENV_PREFIX,
               data
             });

--- a/src/environments/RemoveEnvironmentButton.tsx
+++ b/src/environments/RemoveEnvironmentButton.tsx
@@ -5,7 +5,6 @@ import { memo, useCallback } from 'react';
 import { useAxios } from '../common/AxiosContext';
 import { ButtonWithConfirm } from '../common/ButtonWithConfirm';
 import { ENV_PREFIX } from './types';
-import { API_PREFIX } from '../common/axiosclient';
 
 interface IRemoveEnvironmentButton {
   name: string;
@@ -18,7 +17,6 @@ function _RemoveEnvironmentButton(props: IRemoveEnvironmentButton) {
   const removeEnv = useCallback(async () => {
     const response = await axios.serviceClient.request({
       method: 'delete',
-      prefix: API_PREFIX,
       path: ENV_PREFIX,
       data: { name: props.image }
     });

--- a/src/servers/App.tsx
+++ b/src/servers/App.tsx
@@ -22,12 +22,6 @@ export interface IAppProps {
 export default function App(props: IAppProps) {
   const jhData = useJupyterhub();
 
-  const hubClient = useMemo(() => {
-    const baseUrl = jhData.hubPrefix;
-    const xsrfToken = jhData.xsrfToken;
-    return new AxiosClient({ baseUrl, xsrfToken });
-  }, [jhData]);
-
   const serviceClient = useMemo(() => {
     const baseUrl = jhData.servicePrefix;
     const xsrfToken = jhData.xsrfToken;
@@ -36,7 +30,7 @@ export default function App(props: IAppProps) {
 
   return (
     <ThemeProvider theme={customTheme}>
-      <AxiosContext.Provider value={{ hubClient, serviceClient }}>
+      <AxiosContext.Provider value={{ serviceClient }}>
         <ScopedCssBaseline>
           <Stack sx={{ padding: 1 }} spacing={1}>
             <NewServerDialog

--- a/src/servers/NewServerDialog.tsx
+++ b/src/servers/NewServerDialog.tsx
@@ -76,7 +76,6 @@ function _NewServerDialog(props: INewServerDialogProps) {
       setLoading(true);
       await axios.serviceClient.request({
         method: 'post',
-        prefix: 'api',
         path: SERVER_PREFIX,
         data
       });

--- a/src/servers/NewServerDialog.tsx
+++ b/src/servers/NewServerDialog.tsx
@@ -76,9 +76,9 @@ function _NewServerDialog(props: INewServerDialogProps) {
         path: SERVER_PREFIX,
         data
       });
-      // window.location.reload();
+      window.location.reload();
     } catch (e: any) {
-      console.error(e);
+      alert(e);
     }
   }, [serverName, rowSelectionModel, props.images, axios, jhData]);
   const disabled = useMemo(() => {

--- a/src/servers/NewServerDialog.tsx
+++ b/src/servers/NewServerDialog.tsx
@@ -16,8 +16,8 @@ import { IEnvironmentData } from '../environments/types';
 import { SmallTextField } from '../common/SmallTextField';
 
 import { useAxios } from '../common/AxiosContext';
-import { SPAWN_PREFIX } from '../common/axiosclient';
 import { useJupyterhub } from '../common/JupyterhubContext';
+import { SERVER_PREFIX } from './types';
 export interface INewServerDialogProps {
   images: IEnvironmentData[];
   allowNamedServers: boolean;
@@ -65,22 +65,18 @@ function _NewServerDialog(props: INewServerDialogProps) {
 
   const createServer = useCallback(async () => {
     const imageName = props.images[rowSelectionModel[0] as number].image_name;
-    const data = new FormData();
-    data.append('image', imageName);
-    let path = '';
-    if (serverName.length > 0) {
-      path = `${jhData.user}/${serverName}`;
-    } else {
-      path = jhData.user;
-    }
+    const data: { [key: string]: string } = {
+      imageName,
+      userName: jhData.user,
+      serverName
+    };
     try {
-      await axios.hubClient.request({
+      await axios.serviceClient.request({
         method: 'post',
-        prefix: SPAWN_PREFIX,
-        path,
+        path: SERVER_PREFIX,
         data
       });
-      window.location.reload();
+      // window.location.reload();
     } catch (e: any) {
       console.error(e);
     }

--- a/src/servers/NewServerDialog.tsx
+++ b/src/servers/NewServerDialog.tsx
@@ -18,6 +18,7 @@ import { SmallTextField } from '../common/SmallTextField';
 import { useAxios } from '../common/AxiosContext';
 import { useJupyterhub } from '../common/JupyterhubContext';
 import { SERVER_PREFIX } from './types';
+
 export interface INewServerDialogProps {
   images: IEnvironmentData[];
   allowNamedServers: boolean;
@@ -36,6 +37,7 @@ function _NewServerDialog(props: INewServerDialogProps) {
   const axios = useAxios();
   const jhData = useJupyterhub();
   const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [serverName, setServerName] = useState<string>('');
   const handleOpen = () => {
     setOpen(true);
@@ -71,13 +73,16 @@ function _NewServerDialog(props: INewServerDialogProps) {
       serverName
     };
     try {
+      setLoading(true);
       await axios.serviceClient.request({
         method: 'post',
+        prefix: 'api',
         path: SERVER_PREFIX,
         data
       });
       window.location.reload();
     } catch (e: any) {
+      setLoading(false);
       alert(e);
     }
   }, [serverName, rowSelectionModel, props.images, axios, jhData]);
@@ -102,6 +107,7 @@ function _NewServerDialog(props: INewServerDialogProps) {
       </Box>
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth={'md'}>
         <DialogTitle>Server Options</DialogTitle>
+
         <DialogContent>
           {props.allowNamedServers && (
             <Box sx={{ padding: 1 }}>
@@ -127,8 +133,10 @@ function _NewServerDialog(props: INewServerDialogProps) {
             selectable
             rowSelectionModel={rowSelectionModel}
             setRowSelectionModel={updateSelectedRow}
+            loading={loading}
           />
         </DialogContent>
+
         <DialogActions>
           <Button variant="contained" color="error" onClick={handleClose}>
             Cancel

--- a/src/servers/OpenServerButton.tsx
+++ b/src/servers/OpenServerButton.tsx
@@ -5,7 +5,7 @@ import { useAxios } from '../common/AxiosContext';
 import { useJupyterhub } from '../common/JupyterhubContext';
 import urlJoin from 'url-join';
 import SyncIcon from '@mui/icons-material/Sync';
-import { SPAWN_PREFIX } from '../common/axiosclient';
+import { SERVER_PREFIX } from './types';
 
 interface IOpenServerButton {
   url: string;
@@ -30,7 +30,7 @@ function _OpenServerButton(props: IOpenServerButton) {
       props.serverName,
       'progress'
     );
-    if (xsrfToken) {
+    if (!xsrfToken) {
       // add xsrf token to url parameter
       const sep = progressUrl.indexOf('?') === -1 ? '?' : '&';
       progressUrl = progressUrl + sep + '_xsrf=' + xsrfToken;
@@ -51,13 +51,15 @@ function _OpenServerButton(props: IOpenServerButton) {
 
   const createServer = useCallback(async () => {
     const imageName = props.imageName;
-    const data = new FormData();
-    data.append('image', imageName);
+    const data = {
+      imageName,
+      userName: jhData.user,
+      serverName: props.serverName
+    };
     try {
-      await axios.hubClient.request({
+      await axios.serviceClient.request({
         method: 'post',
-        prefix: SPAWN_PREFIX,
-        path: `${jhData.user}/${props.serverName}`,
+        path: SERVER_PREFIX,
         data
       });
       window.open(props.url, '_blank')?.focus();

--- a/src/servers/OpenServerButton.tsx
+++ b/src/servers/OpenServerButton.tsx
@@ -26,7 +26,6 @@ function _OpenServerButton(props: IOpenServerButton) {
     try {
       await axios.serviceClient.request({
         method: 'post',
-        prefix: 'api',
         path: SERVER_PREFIX,
         data
       });

--- a/src/servers/RemoveServerButton.tsx
+++ b/src/servers/RemoveServerButton.tsx
@@ -19,6 +19,7 @@ function _RemoveServerButton(props: IRemoveServerButton) {
       await axios.serviceClient.request({
         method: 'delete',
         path: SERVER_PREFIX,
+        prefix: 'api',
         data: {
           userName: jhData.user,
           serverName: props.server

--- a/src/servers/RemoveServerButton.tsx
+++ b/src/servers/RemoveServerButton.tsx
@@ -19,7 +19,6 @@ function _RemoveServerButton(props: IRemoveServerButton) {
       await axios.serviceClient.request({
         method: 'delete',
         path: SERVER_PREFIX,
-        prefix: 'api',
         data: {
           userName: jhData.user,
           serverName: props.server

--- a/src/servers/RemoveServerButton.tsx
+++ b/src/servers/RemoveServerButton.tsx
@@ -5,7 +5,7 @@ import { memo, useCallback } from 'react';
 import { useAxios } from '../common/AxiosContext';
 import { ButtonWithConfirm } from '../common/ButtonWithConfirm';
 import { useJupyterhub } from '../common/JupyterhubContext';
-import { API_PREFIX } from '../common/axiosclient';
+import { SERVER_PREFIX } from './types';
 
 interface IRemoveServerButton {
   server: string;
@@ -15,24 +15,20 @@ function _RemoveServerButton(props: IRemoveServerButton) {
   const axios = useAxios();
   const jhData = useJupyterhub();
   const removeEnv = useCallback(async () => {
-    let path = '';
-    if (props.server.length > 0) {
-      path = `users/${jhData.user}/servers/${props.server}`;
-    } else {
-      path = `users/${jhData.user}/server`;
-    }
     try {
-      await axios.hubClient.request({
+      await axios.serviceClient.request({
         method: 'delete',
-        prefix: API_PREFIX,
-        path,
-        data: { remove: props.server.length > 0 }
+        path: SERVER_PREFIX,
+        data: {
+          userName: jhData.user,
+          serverName: props.server
+        }
       });
       window.location.reload();
     } catch (e: any) {
       console.error(e);
     }
-  }, [props.server, axios, jhData]);
+  }, [props.server, axios, jhData.user]);
 
   return (
     <ButtonWithConfirm

--- a/src/servers/ServersList.tsx
+++ b/src/servers/ServersList.tsx
@@ -93,7 +93,6 @@ function _ServerList(props: IServerListProps) {
 
     return allServers;
   }, [props]);
-
   return (
     <Box sx={{ padding: 1 }}>
       <DataGrid

--- a/src/servers/types.ts
+++ b/src/servers/types.ts
@@ -1,3 +1,4 @@
+export const SERVER_PREFIX = 'servers';
 export interface IServerData {
   name: string;
   url: string;

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -128,12 +128,12 @@ class SpawnerMixin(Configurable):
         imagename = self.user_options.get("image")
         async with Docker() as docker:
             image = await docker.images.inspect(imagename)
-        mem_limit = image["ContainerConfig"]["Labels"].get(
-            "tljh_repo2docker.mem_limit", None
-        )
-        cpu_limit = image["ContainerConfig"]["Labels"].get(
-            "tljh_repo2docker.cpu_limit", None
-        )
+        config = image.get("ContainerConfig", None)
+        if not config:
+            config = image.get("Config", {})
+        label = config.get("Labels", {})
+        mem_limit = label.get("tljh_repo2docker.mem_limit", None)
+        cpu_limit = label.get("tljh_repo2docker.cpu_limit", None)
 
         # override the spawner limits if defined in the image
         if mem_limit:

--- a/tljh_repo2docker/app.py
+++ b/tljh_repo2docker/app.py
@@ -157,6 +157,7 @@ class TljhRepo2Docker(Application):
         handlers = []
         static_path = str(HERE / "static")
         server_url = url_path_join(self.service_prefix, r"servers")
+        environments_url = url_path_join(self.service_prefix, r"environments")
         handlers.extend(
             [
                 (
@@ -176,7 +177,7 @@ class TljhRepo2Docker(Application):
                 (self.service_prefix, web.RedirectHandler, {"url": server_url}),
                 (server_url, ServersHandler),
                 (
-                    url_path_join(self.service_prefix, r"environments"),
+                    environments_url,
                     EnvironmentsHandler,
                 ),
                 (url_path_join(self.service_prefix, r"api/environments"), BuildHandler),

--- a/tljh_repo2docker/app.py
+++ b/tljh_repo2docker/app.py
@@ -16,6 +16,7 @@ from .builder import BuildHandler
 from .environments import EnvironmentsHandler
 from .logs import LogsHandler
 from .servers import ServersHandler
+from .servers_api import ServersAPIHandler
 
 if os.environ.get("JUPYTERHUB_API_TOKEN"):
     from jupyterhub.services.auth import HubOAuthCallbackHandler
@@ -157,7 +158,6 @@ class TljhRepo2Docker(Application):
         handlers = []
         static_path = str(HERE / "static")
         server_url = url_path_join(self.service_prefix, r"servers")
-        environments_url = url_path_join(self.service_prefix, r"environments")
         handlers.extend(
             [
                 (
@@ -177,7 +177,11 @@ class TljhRepo2Docker(Application):
                 (self.service_prefix, web.RedirectHandler, {"url": server_url}),
                 (server_url, ServersHandler),
                 (
-                    environments_url,
+                    url_path_join(self.service_prefix, r"api/servers"),
+                    ServersAPIHandler,
+                ),
+                (
+                    url_path_join(self.service_prefix, r"environments"),
                     EnvironmentsHandler,
                 ),
                 (url_path_join(self.service_prefix, r"api/environments"), BuildHandler),

--- a/tljh_repo2docker/base.py
+++ b/tljh_repo2docker/base.py
@@ -42,7 +42,7 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
             api_token = os.environ.get("JUPYTERHUB_API_TOKEN", None)
             BaseHandler._client = AsyncClient(
                 base_url=api_url,
-                headers={f"Authorization": f"Bearer {api_token}"},
+                headers={"Authorization": f"Bearer {api_token}"},
             )
         return BaseHandler._client
 

--- a/tljh_repo2docker/base.py
+++ b/tljh_repo2docker/base.py
@@ -85,7 +85,7 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
             service_prefix=self.settings.get("service_prefix", "/"),
             hub_prefix=self.settings.get("hub_prefix", "/"),
             base_url=base_url,
-            logo_url=url_path_join(base_url,'hub','home'),
+            logo_url=url_path_join(base_url, "hub", "home"),
             logout_url=self.settings.get(
                 "logout_url", url_path_join(base_url, "logout")
             ),

--- a/tljh_repo2docker/base.py
+++ b/tljh_repo2docker/base.py
@@ -85,6 +85,7 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
             service_prefix=self.settings.get("service_prefix", "/"),
             hub_prefix=self.settings.get("hub_prefix", "/"),
             base_url=base_url,
+            logo_url=url_path_join(base_url,'hub','home'),
             logout_url=self.settings.get(
                 "logout_url", url_path_join(base_url, "logout")
             ),

--- a/tljh_repo2docker/model.py
+++ b/tljh_repo2docker/model.py
@@ -18,15 +18,14 @@ class UserModel:
     def all_spawners(self) -> list:
         sp = []
         for server in self.servers.values():
-            if len(server["name"]) > 0:
+            active = bool(server.get("pending", None) or server.get("ready", False))
+            if active or len(server["name"]) > 0:
                 sp.append(
                     {
                         "name": server.get("name", ""),
                         "url": server.get("url", ""),
                         "last_activity": server.get("last_activity", None),
-                        "active": bool(
-                            server.get("pending", None) or server.get("ready", False)
-                        ),
+                        "active": active,
                         "user_options": server.get("user_options", None),
                     }
                 )

--- a/tljh_repo2docker/servers.py
+++ b/tljh_repo2docker/servers.py
@@ -1,7 +1,7 @@
 from inspect import isawaitable
 
 from tornado import web
-from jupyterhub.utils import url_path_join
+
 from .base import BaseHandler
 from .docker import list_images
 
@@ -17,7 +17,6 @@ class ServersHandler(BaseHandler):
         user_data = await self.fetch_user()
 
         server_data = user_data.all_spawners()
-
         named_server_limit = 0
         result = self.render_template(
             "servers.html",
@@ -33,50 +32,3 @@ class ServersHandler(BaseHandler):
             self.write(await result)
         else:
             self.write(result)
-
-    @web.authenticated
-    async def post(self):
-        data = self.get_json_body()
-        image_name = data.get("imageName", None)
-        user_name = data.get("userName", None)
-        server_name = data.get("serverName", "")
-        if user_name != self.current_user["name"]:
-            raise web.HTTPError(403, "Unauthorized")
-        if not image_name:
-            raise web.HTTPError(400, "Missing image name")
-
-        post_data = {"image": image_name}
-
-        path = ""
-        if len(server_name) > 0:
-            path = url_path_join("users", user_name, "servers", server_name)
-        else:
-            path = url_path_join("users", user_name, "server")
-        try:
-            response = await self.client.post(path, json=post_data)
-            response.raise_for_status()
-        except Exception:
-            raise web.HTTPError(500, "Server error")
-        self.finish(0)
-
-    @web.authenticated
-    async def delete(self):
-        data = self.get_json_body()
-        user_name = data.get("userName", None)
-        server_name = data.get("serverName", "")
-        if user_name != self.current_user["name"]:
-            raise web.HTTPError(403, "Unauthorized")
-
-        path = ""
-        post_data = {}
-        if len(server_name) > 0:
-            path = url_path_join("users", user_name, "servers", server_name)
-            post_data = {"remove": True}
-        else:
-            path = url_path_join("users", user_name, "server")
-        try:
-            response = await self.client.request("DELETE", path, json=post_data)
-            response.raise_for_status()
-        except Exception as e:
-            raise web.HTTPError(500, "Server error")
-        self.finish("0")

--- a/tljh_repo2docker/servers.py
+++ b/tljh_repo2docker/servers.py
@@ -1,7 +1,8 @@
 from inspect import isawaitable
 
+import requests
 from tornado import web
-
+from jupyterhub.utils import url_path_join
 from .base import BaseHandler
 from .docker import list_images
 
@@ -33,3 +34,27 @@ class ServersHandler(BaseHandler):
             self.write(await result)
         else:
             self.write(result)
+
+    @web.authenticated
+    async def post(self):
+        data = self.get_json_body()
+        image_name = data.get("imageName", None)
+        user_name = data.get("userName", None)
+        server_name = data.get("serverName", "")
+        if user_name != self.current_user["name"]:
+            raise web.HTTPError(403, "Unauthorized")
+        if not image_name:
+            raise web.HTTPError(400, "Missing image name")
+
+        post_data = {"image": image_name}
+
+        path = ""
+        if len(server_name) > 0:
+            path = url_path_join("users", user_name, "servers", server_name)
+        else:
+            path = url_path_join("users", user_name, "server")
+        try:
+            response = await self.client.post(path, json=post_data)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            print(e)

--- a/tljh_repo2docker/servers_api.py
+++ b/tljh_repo2docker/servers_api.py
@@ -1,0 +1,55 @@
+from jupyterhub.utils import url_path_join
+from tornado import web
+
+from .base import BaseHandler
+
+
+class ServersAPIHandler(BaseHandler):
+    """
+    Handler to manage single servers
+    """
+
+    @web.authenticated
+    async def post(self):
+        data = self.get_json_body()
+        image_name = data.get("imageName", None)
+        user_name = data.get("userName", None)
+        server_name = data.get("serverName", "")
+        if user_name != self.current_user["name"]:
+            raise web.HTTPError(403, "Unauthorized")
+        if not image_name:
+            raise web.HTTPError(400, "Missing image name")
+
+        post_data = {"image": image_name}
+
+        path = ""
+        if len(server_name) > 0:
+            path = url_path_join("users", user_name, "servers", server_name)
+        else:
+            path = url_path_join("users", user_name, "server")
+        try:
+            response = await self.client.post(path, json=post_data)
+            response.raise_for_status()
+        except Exception:
+            raise web.HTTPError(500, "Server error")
+
+    @web.authenticated
+    async def delete(self):
+        data = self.get_json_body()
+        user_name = data.get("userName", None)
+        server_name = data.get("serverName", "")
+        if user_name != self.current_user["name"]:
+            raise web.HTTPError(403, "Unauthorized")
+
+        path = ""
+        post_data = {}
+        if len(server_name) > 0:
+            path = url_path_join("users", user_name, "servers", server_name)
+            post_data = {"remove": True}
+        else:
+            path = url_path_join("users", user_name, "server")
+        try:
+            response = await self.client.request("DELETE", path, json=post_data)
+            response.raise_for_status()
+        except Exception:
+            raise web.HTTPError(500, "Server error")


### PR DESCRIPTION
## Reference

Due to the changes in JupyterHub 4.1.2, users can not send a POST request to the JupyterHub server from `tljh-repo2docker`'s frontend anymore. This PR adds new endpoints to start and stop single-server from the service's backend


## Code changes

- New endpoints: `/api/servers` allowing users to start and stop a single server.
- The frontend is updated appropriately to use the new endpoint.