### PR TITLE
Make tljh_extra_hub_pip_packages hook match pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -31,7 +31,7 @@ jobs:
           python -m build .
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
           path: |
@@ -47,7 +47,7 @@ jobs:
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
 
@@ -74,13 +74,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Download app package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
 
@@ -114,13 +114,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Download app package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tljh_repo2docker-artifacts
 
@@ -138,7 +138,7 @@ jobs:
         run: npm install
 
       - name: Set up browser cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ github.workspace }}/pw-browsers
@@ -155,9 +155,9 @@ jobs:
 
       - name: Upload Playwright Test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tljh-playwright-tests
+          name: tljh-playwright-tests-${{ matrix.build-backend }}
           path: |
             ui-tests/local-test-results
             ui-tests/binderhub-test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -22,7 +22,7 @@ jobs:
           version_spec: next
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tljh_repo2docker-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -182,7 +182,7 @@ if hookimpl:
 
     @hookimpl
     def tljh_extra_hub_pip_packages():
-        return ["dockerspawner~=0.11", "jupyter_client>=6.1,<8", "aiodocker~=0.19"]
+        return ["dockerspawner~=12.1", "jupyter_client>=6.1,<8", "aiodocker~=0.19"]
 
 else:
     tljh_custom_jupyterhub_config = None

--- a/tljh_repo2docker/tests/local_build/test_builder.py
+++ b/tljh_repo2docker/tests/local_build/test_builder.py
@@ -10,8 +10,9 @@ async def test_add_environment(app, minimal_repo, image_name):
     r = await add_environment(app, repo=minimal_repo, name=name, ref=ref)
     assert r.status_code == 200
     image = await wait_for_image(image_name=image_name)
+    config = image.get("ContainerConfig", image.get("Config", {}))
     assert (
-        image["ContainerConfig"]["Labels"]["tljh_repo2docker.image_name"] == image_name
+        config["Labels"]["tljh_repo2docker.image_name"] == image_name
     )
 
 
@@ -41,9 +42,9 @@ async def test_uppercase_repo(app, minimal_repo_uppercase, generated_image_name)
     r = await add_environment(app, repo=minimal_repo_uppercase)
     assert r.status_code == 200
     image = await wait_for_image(image_name=generated_image_name)
+    config = image.get("ContainerConfig", image.get("Config", {}))
     assert (
-        image["ContainerConfig"]["Labels"]["tljh_repo2docker.image_name"]
-        == generated_image_name
+        config["Labels"]["tljh_repo2docker.image_name"] == generated_image_name
     )
 
 


### PR DESCRIPTION
I was wondering why even a new install ends up with a really old version of this.
That hook is probably why.