### PR TITLE
Restore self.log logger in BaseHandler

### DIFF
--- a/tljh_repo2docker/base.py
+++ b/tljh_repo2docker/base.py
@@ -12,6 +12,7 @@ from jupyterhub.services.auth import HubOAuthenticated
 from jupyterhub.utils import url_path_join
 from sqlalchemy.ext.asyncio import AsyncSession
 from tornado import web
+from tornado.log import app_log
 
 from tljh_repo2docker import TLJH_R2D_ADMIN_SCOPE
 from tljh_repo2docker.database.manager import ImagesDatabaseManager
@@ -46,6 +47,10 @@ class BaseHandler(HubOAuthenticated, web.RequestHandler):
     """
 
     _client = None
+
+    @property
+    def log(self):
+        return self.settings.get('log', app_log)
 
     @property
     def client(self):


### PR DESCRIPTION
This is analog to how it's implemented in jupyterhub itself: https://github.com/jupyterhub/jupyterhub/blob/main/jupyterhub/handlers/base.py#L118
Without this, I saw some exceptions in my logs trying to access the non-existent logger under Jupyterhub 5.