### PR TITLE
Allow buildkit-built images to execute

### DIFF
--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -134,10 +134,11 @@ class SpawnerMixin(Configurable):
         imagename = self.user_options.get("image")
         async with Docker() as docker:
             image = await docker.images.inspect(imagename)
-        config = image.get("ContainerConfig", None)
-        if not config:
-            config = image.get("Config", {})
-        label = config.get("Labels", {})
+        label = {
+            **(image.get("ContainerConfig", {}).get("Labels") or {}),
+            **(image.get("Config", {}).get("Labels") or {})
+            }
+
         mem_limit = label.get("tljh_repo2docker.mem_limit", None)
         cpu_limit = label.get("tljh_repo2docker.cpu_limit", None)
 


### PR DESCRIPTION
Depending on the Docker version, some images may have labels in either the Config or the ContainerConfig field.  The ContainerConfig field may also have valid keys but empty values or be missing entirely depending on the version.

This patch takes the labels from both fields (with Config overriding ContainerConfig if there is a clash).

https://docs.docker.com/engine/deprecated/#container-and-containerconfig-fields-in-image-inspect