### PR TITLE
Update `dockerspawner` and `aiodocker`, TLJH 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           sudo rm -rf $(which node)
           sudo rm -rf $(which node)
 
-          python -m pip install git+https://github.com/jupyterhub/the-littlest-jupyterhub tljh_repo2docker*.whl
+          python -m pip install git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0 tljh_repo2docker*.whl
 
       - name: Test import
         run: python -c "import tljh_repo2docker"

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ sudo apt update && sudo apt install -y docker-ce
 # pull the repo2docker image
 sudo docker pull quay.io/jupyterhub/repo2docker:main
 
-# install TLJH 1.0
+# install TLJH 2.0
 curl https://tljh.jupyter.org/bootstrap.py
   | sudo python3 - \
-    --version 1.0.0 \
+    --version 2.0.0 \
     --admin test:test \
     --plugin tljh-repo2docker
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/jupyterhub/the-littlest-jupyterhub@1.0.0
+git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0
 git+https://github.com/jupyterhub/binderhub.git@main
 jupyterhub>=5,<6
 alembic>=1.13.0,<1.14

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0
 git+https://github.com/jupyterhub/binderhub.git@main
 jupyterhub>=5,<6
-alembic>=1.13.0,<1.14
+alembic>=1.14
 pytest
 pytest-aiohttp
 pytest-asyncio

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/jupyterhub/the-littlest-jupyterhub@2.0.0
 git+https://github.com/jupyterhub/binderhub.git@main
 jupyterhub>=5,<6
-alembic>=1.14
+alembic>=1.14,<1.15
 pytest
 pytest-aiohttp
 pytest-asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires = ["hatchling>=1.5.0,<2", "hatch-nodejs-version>=0.3.2"]
 
 [project]
 dependencies = [
-  "aiodocker>=0.21.0",
-  "dockerspawner>=13.0.0",
+  "aiodocker>=0.21.0,<0.22.0",
+  "dockerspawner>=14.0.0,<15.0.0",
   "jupyter_client>=6.1,<8",
   "httpx",
   "sqlalchemy>=2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
   "httpx",
   "sqlalchemy>=2",
   "pydantic>=2,<3",
-  "alembic>=1.13,<2",
+  "alembic>=1.14,<1.15",
   "jupyter-repo2docker>=2024,<2025",
   "aiosqlite~=0.19.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires = ["hatchling>=1.5.0,<2", "hatch-nodejs-version>=0.3.2"]
 
 [project]
 dependencies = [
-  "aiodocker~=0.19",
-  "dockerspawner~=12.1",
+  "aiodocker>=0.21.0",
+  "dockerspawner>=13.0.0",
   "jupyter_client>=6.1,<8",
   "httpx",
   "sqlalchemy>=2",

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -203,7 +203,11 @@ if hookimpl:
 
     @hookimpl
     def tljh_extra_hub_pip_packages():
-        return ["dockerspawner>=13.0.0", "jupyter_client>=6.1,<8", "aiodocker>=0.21.0"]
+        return [
+            "dockerspawner>=14.0.0,<15.0.0",
+            "jupyter_client>=6.1,<8",
+            "aiodocker>=0.21.0,<0.22.0",
+        ]
 
 else:
     tljh_custom_jupyterhub_config = None

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -132,48 +132,28 @@ class SpawnerMixin(Configurable):
         Set the user environment limits if they are defined in the image
         """
         imagename = self.user_options.get("image")
-        if not imagename:
-            self.log.warning("No image specified in user_options")
-            return
+        async with Docker() as docker:
+            image = await docker.images.inspect(imagename)
+        config = image.get("ContainerConfig", None)
+        if not config:
+            config = image.get("Config", {})
+        label = config.get("Labels", {})
+        mem_limit = label.get("tljh_repo2docker.mem_limit", None)
+        cpu_limit = label.get("tljh_repo2docker.cpu_limit", None)
 
-        try:
-            async with Docker() as docker:
-                try:
-                    image = await docker.images.inspect(imagename)
-                except Exception as e:
-                    self.log.error(f"Failed to inspect image {imagename}: {str(e)}")
-                    return
+        # override the spawner limits if defined in the image
+        if mem_limit:
+            self.mem_limit = mem_limit
+        if cpu_limit:
+            self.cpu_limit = float(cpu_limit)
 
-            # Handle different Docker API response structures
-            config = image.get("ContainerConfig") or image.get("Config") or {}
-            labels = config.get("Labels") or {}
-
-            if not isinstance(labels, dict):
-                self.log.warning(f"Unexpected labels type: {type(labels)}")
-                labels = {}
-
-            mem_limit = labels.get("tljh_repo2docker.mem_limit")
-            cpu_limit = labels.get("tljh_repo2docker.cpu_limit")
-
-            # override the spawner limits if defined in the image
-            if mem_limit:
-                self.mem_limit = mem_limit
-            if cpu_limit:
-                try:
-                    self.cpu_limit = float(cpu_limit)
-                except (ValueError, TypeError):
-                    self.log.error(f"Invalid CPU limit value: {cpu_limit}")
-
-            if self.cpu_limit:
-                self.extra_host_config.update(
-                    {
-                        "cpu_period": CPU_PERIOD,
-                        "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
-                    }
-                )
-        except Exception as e:
-            self.log.error(f"Error in set_limits: {str(e)}")
-            raise
+        if self.cpu_limit:
+            self.extra_host_config.update(
+                {
+                    "cpu_period": CPU_PERIOD,
+                    "cpu_quota": int(float(CPU_PERIOD) * self.cpu_limit),
+                }
+            )
 
 
 class Repo2DockerSpawner(SpawnerMixin, DockerSpawner):
@@ -203,11 +183,7 @@ if hookimpl:
 
     @hookimpl
     def tljh_extra_hub_pip_packages():
-        return [
-            "dockerspawner>=14.0.0,<15.0.0",
-            "jupyter_client>=6.1,<8",
-            "aiodocker>=0.21.0,<0.22.0",
-        ]
+        return ["dockerspawner~=12.1", "jupyter_client>=6.1,<8", "aiodocker~=0.19"]
 
 else:
     tljh_custom_jupyterhub_config = None

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -202,7 +202,7 @@ if hookimpl:
 
     @hookimpl
     def tljh_extra_hub_pip_packages():
-        return ["dockerspawner~=12.1", "jupyter_client>=6.1,<8", "aiodocker~=0.19"]
+        return ["dockerspawner>=13.0.0", "jupyter_client>=6.1,<8", "aiodocker>=0.21.0"]
 
 else:
     tljh_custom_jupyterhub_config = None

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -196,6 +196,7 @@ if hookimpl:
         c.JupyterHub.spawner_class = Repo2DockerSpawner
 
         # spawner
+        c.DockerSpawner.allowed_images = "*"
         c.DockerSpawner.cmd = ["jupyterhub-singleuser"]
         c.DockerSpawner.pull_policy = "Never"
         c.DockerSpawner.remove = True

--- a/ui-tests/tests/ui.test.ts
+++ b/ui-tests/tests/ui.test.ts
@@ -152,7 +152,7 @@ test.describe('tljh_repo2docker UI Tests', () => {
     await Promise.all([
       page.waitForResponse(
         response =>
-          response.url().includes('/api/servers') && response.status() === 200
+          response.url().includes('/servers') && response.status() === 200
       ),
       createServer.click()
     ]);

--- a/ui-tests/tests/ui.test.ts
+++ b/ui-tests/tests/ui.test.ts
@@ -150,9 +150,9 @@ test.describe('tljh_repo2docker UI Tests', () => {
     });
 
     await Promise.all([
-      page.waitForResponse(response =>
-        response.url().includes('/api/servers') &&
-        response.status() === 200
+      page.waitForResponse(
+        response =>
+          response.url().includes('/api/servers') && response.status() === 200
       ),
       createServer.click()
     ]);

--- a/ui-tests/tests/ui.test.ts
+++ b/ui-tests/tests/ui.test.ts
@@ -148,20 +148,10 @@ test.describe('tljh_repo2docker UI Tests', () => {
     const createServer = await page.getByRole('button', {
       name: 'Create Server'
     });
-
-    await Promise.all([
-      page.waitForResponse(
-        response =>
-          response.url().includes('/servers') && response.status() === 200
-      ),
-      createServer.click()
-    ]);
+    await createServer.click();
     await expect(createServer).toHaveCount(0, { timeout: 20000 });
-
     await page.waitForURL('**/servers');
-    await page.waitForSelector('div:has-text("test-server")', {
-      timeout: 30000
-    });
+    await page.waitForTimeout(1000);
 
     expect(await page.screenshot()).toMatchSnapshot('running-servers.png');
   });

--- a/ui-tests/tests/ui.test.ts
+++ b/ui-tests/tests/ui.test.ts
@@ -156,6 +156,7 @@ test.describe('tljh_repo2docker UI Tests', () => {
       ),
       createServer.click()
     ]);
+    await expect(createServer).toHaveCount(0, { timeout: 20000 });
 
     await page.waitForURL('**/servers');
     await page.waitForSelector('div:has-text("test-server")', {

--- a/ui-tests/tests/ui.test.ts
+++ b/ui-tests/tests/ui.test.ts
@@ -148,10 +148,19 @@ test.describe('tljh_repo2docker UI Tests', () => {
     const createServer = await page.getByRole('button', {
       name: 'Create Server'
     });
-    await createServer.click();
-    await expect(createServer).toHaveCount(0, { timeout: 20000 });
+
+    await Promise.all([
+      page.waitForResponse(response =>
+        response.url().includes('/api/servers') &&
+        response.status() === 200
+      ),
+      createServer.click()
+    ]);
+
     await page.waitForURL('**/servers');
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('div:has-text("test-server")', {
+      timeout: 30000
+    });
 
     expect(await page.screenshot()).toMatchSnapshot('running-servers.png');
   });


### PR DESCRIPTION
Investigating https://github.com/plasmabio/plasma/issues/227

Fixes https://github.com/plasmabio/tljh-repo2docker/issues/106

- [x] Bump `dockerspawner`. Handle breaking change by adding:

```py
c.DockerSpawner.allowed_images = "*"
```

- [x] Bump `aiodocker`
- [x] Handle different Docker API response structures