### PR TITLE
[1.x] Backport buildkit-built images fix

### DIFF
--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -134,12 +134,13 @@ class SpawnerMixin(Configurable):
         async with Docker() as docker:
             image = await docker.images.inspect(imagename)
 
-        mem_limit = image["ContainerConfig"]["Labels"].get(
-            "tljh_repo2docker.mem_limit", None
-        )
-        cpu_limit = image["ContainerConfig"]["Labels"].get(
-            "tljh_repo2docker.cpu_limit", None
-        )
+        label = {
+            **(image.get("ContainerConfig", {}).get("Labels") or {}),
+            **(image.get("Config", {}).get("Labels") or {})
+        }
+
+        mem_limit = label.get("tljh_repo2docker.mem_limit", None)
+        cpu_limit = label.get("tljh_repo2docker.cpu_limit", None)
 
         # override the spawner limits if defined in the image
         if mem_limit:

--- a/tljh_repo2docker/tests/test_builder.py
+++ b/tljh_repo2docker/tests/test_builder.py
@@ -42,9 +42,11 @@ async def test_uppercase_repo(app, minimal_repo_uppercase, generated_image_name)
     r = await add_environment(app, repo=minimal_repo_uppercase)
     assert r.status_code == 200
     image = await wait_for_image(image_name=generated_image_name)
-    assert (
-        image["ContainerConfig"]["Labels"]["tljh_repo2docker.image_name"] == generated_image_name
-    )
+    label = {
+        **(image.get("ContainerConfig", {}).get("Labels") or {}),
+        **(image.get("Config", {}).get("Labels") or {})
+    }
+    assert label.get("tljh_repo2docker.image_name", None) == generated_image_name
 
 
 @pytest.mark.asyncio

--- a/tljh_repo2docker/tests/test_builder.py
+++ b/tljh_repo2docker/tests/test_builder.py
@@ -11,9 +11,11 @@ async def test_add_environment(app, minimal_repo, image_name):
     r = await add_environment(app, repo=minimal_repo, name=name, ref=ref)
     assert r.status_code == 200
     image = await wait_for_image(image_name=image_name)
-    assert (
-        image["ContainerConfig"]["Labels"]["tljh_repo2docker.image_name"] == image_name
-    )
+    label = {
+        **(image.get("ContainerConfig", {}).get("Labels") or {}),
+        **(image.get("Config", {}).get("Labels") or {})
+    }
+    assert label.get("tljh_repo2docker.image_name", None) == image_name
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Backport https://github.com/plasmabio/tljh-repo2docker/pull/103 to the `1.x` branch.