### PR TITLE
Database

### DIFF
--- a/src/environments/EnvironmentList.tsx
+++ b/src/environments/EnvironmentList.tsx
@@ -1,4 +1,3 @@
-import { IconButton } from '@mui/material';
 import {
   DataGrid,
   GridColDef,
@@ -7,7 +6,6 @@ import {
 } from '@mui/x-data-grid';
 import { IEnvironmentData } from './types';
 import { memo, useMemo, useState } from 'react';
-import CheckIcon from '@mui/icons-material/Check';
 
 import { Box } from '@mui/system';
 import { RemoveEnvironmentButton } from './RemoveEnvironmentButton';
@@ -69,16 +67,24 @@ const columns: GridColDef[] = [
     width: 150,
     hideSortIcons: true,
     renderCell: params => {
-      return params.value === 'built' ? (
-        <IconButton>
-          <CheckIcon color="success" />
-        </IconButton>
-      ) : params.value === 'building' ? (
-        <EnvironmentLogButton
-          name={params.row.display_name}
-          image={params.row.uid ?? params.row.image_name}
-        />
-      ) : null;
+      const image = params.row.uid ?? params.row.image_name;
+      const name = params.row.display_name;
+      if (params.value === 'built') {
+        return (
+          <EnvironmentLogButton name={name} image={image} status="built" />
+        );
+      }
+      if (params.value === 'building') {
+        return (
+          <EnvironmentLogButton name={name} image={image} status="building" />
+        );
+      }
+      if (params.value === 'failed') {
+        return (
+          <EnvironmentLogButton name={name} image={image} status="failed" />
+        );
+      }
+      return null;
     }
   },
   {

--- a/src/environments/LogDialog.tsx
+++ b/src/environments/LogDialog.tsx
@@ -77,18 +77,28 @@ function _EnvironmentLogButton(props: IEnvironmentLogButton) {
       eventSource.onmessage = event => {
         const data = JSON.parse(event.data);
 
-        terminal.write(data.message);
-        fitAddon.fit();
         if (data.phase === 'built') {
+          terminal.reset();
+          if (data.message) {
+            terminal.write(data.message);
+            fitAddon.fit();
+          }
           eventSource.close();
           setBuildResult('built');
           return;
         }
         if (data.phase === 'error') {
+          terminal.reset();
+          if (data.message) {
+            terminal.write(data.message);
+            fitAddon.fit();
+          }
           eventSource.close();
           setBuildResult('failed');
           return;
         }
+        terminal.write(data.message);
+        fitAddon.fit();
       };
     }
   }, [jhData, props.image]);

--- a/src/environments/LogDialog.tsx
+++ b/src/environments/LogDialog.tsx
@@ -1,6 +1,7 @@
 import 'xterm/css/xterm.css';
 
 import CheckIcon from '@mui/icons-material/Check';
+import ErrorIcon from '@mui/icons-material/Error';
 import SyncIcon from '@mui/icons-material/Sync';
 import { Button, IconButton } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
@@ -16,6 +17,7 @@ import { useJupyterhub } from '../common/JupyterhubContext';
 interface IEnvironmentLogButton {
   name: string;
   image: string;
+  status?: 'building' | 'failed' | 'built';
 }
 
 const terminalFactory = () => {
@@ -27,13 +29,17 @@ const terminalFactory = () => {
 
 function _EnvironmentLogButton(props: IEnvironmentLogButton) {
   const jhData = useJupyterhub();
+  const status = props.status ?? 'building';
   const [open, setOpen] = useState(false);
-  const [built, setBuilt] = useState(false);
+  const [buildResult, setBuildResult] = useState<'built' | 'failed' | null>(
+    null
+  );
   const divRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<{ terminal: Terminal; fitAddon: FitAddon }>(
     terminalFactory()
   );
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
   const handleOpen = useCallback(() => {
     setOpen(true);
     if (divRef.current) {
@@ -59,7 +65,6 @@ function _EnvironmentLogButton(props: IEnvironmentLogButton) {
         'logs'
       );
       if (xsrfToken) {
-        // add xsrf token to url parameter
         const sep = logsUrl.indexOf('?') === -1 ? '?' : '&';
         logsUrl = logsUrl + sep + '_xsrf=' + xsrfToken;
       }
@@ -76,12 +81,18 @@ function _EnvironmentLogButton(props: IEnvironmentLogButton) {
         fitAddon.fit();
         if (data.phase === 'built') {
           eventSource.close();
-          setBuilt(true);
+          setBuildResult('built');
+          return;
+        }
+        if (data.phase === 'error') {
+          eventSource.close();
+          setBuildResult('failed');
           return;
         }
       };
     }
   }, [jhData, props.image]);
+
   const handleClose = (
     event?: any,
     reason?: 'backdropClick' | 'escapeKeyDown'
@@ -101,31 +112,45 @@ function _EnvironmentLogButton(props: IEnvironmentLogButton) {
     setOpen(false);
   };
 
+  const effectiveStatus = buildResult ?? status;
+  const dialogTitle =
+    effectiveStatus === 'failed'
+      ? `Build failed: ${props.name}`
+      : effectiveStatus === 'built'
+        ? `Build logs: ${props.name}`
+        : `Creating environment ${props.name}`;
+
+  const triggerButton =
+    effectiveStatus === 'failed' ? (
+      <IconButton onClick={handleOpen} title="View error logs">
+        <ErrorIcon color="error" />
+      </IconButton>
+    ) : effectiveStatus === 'built' ? (
+      <IconButton onClick={handleOpen} title="View build logs">
+        <CheckIcon color="success" />
+      </IconButton>
+    ) : (
+      <IconButton onClick={handleOpen}>
+        <SyncIcon
+          sx={{
+            animation: 'spin 2s linear infinite',
+            '@keyframes spin': {
+              '0%': {
+                transform: 'rotate(360deg)'
+              },
+              '100%': {
+                transform: 'rotate(0deg)'
+              }
+            }
+          }}
+          htmlColor="orange"
+        />
+      </IconButton>
+    );
+
   return (
     <Fragment>
-      {!built && (
-        <IconButton onClick={handleOpen}>
-          <SyncIcon
-            sx={{
-              animation: 'spin 2s linear infinite',
-              '@keyframes spin': {
-                '0%': {
-                  transform: 'rotate(360deg)'
-                },
-                '100%': {
-                  transform: 'rotate(0deg)'
-                }
-              }
-            }}
-            htmlColor="orange"
-          />
-        </IconButton>
-      )}
-      {built && (
-        <IconButton>
-          <CheckIcon color="success" />
-        </IconButton>
-      )}
+      {triggerButton}
       <Dialog
         open={open}
         onClose={handleClose}
@@ -144,7 +169,7 @@ function _EnvironmentLogButton(props: IEnvironmentLogButton) {
           }
         }}
       >
-        <DialogTitle>Creating environment {props.name}</DialogTitle>
+        <DialogTitle>{dialogTitle}</DialogTitle>
         <DialogContent
           sx={{
             flex: 1,

--- a/tljh_repo2docker/__init__.py
+++ b/tljh_repo2docker/__init__.py
@@ -48,7 +48,7 @@ class SpawnerMixin(Configurable):
         config=True,
         help="""
         Jinja2 template for constructing the list of images shown to the user.
-        """
+        """,
     )
 
     async def list_images(self):

--- a/tljh_repo2docker/app.py
+++ b/tljh_repo2docker/app.py
@@ -17,6 +17,7 @@ from .binderhub_builder import BinderHubBuildHandler
 from .binderhub_log import BinderHubLogsHandler
 from .builder import BuildHandler
 from .database.manager import ImagesDatabaseManager
+from .database.schemas import BuildStatusType, DockerImageUpdateSchema
 from .dbutil import async_session_context_factory, sync_to_async_url, upgrade_if_needed
 from .environments import EnvironmentsHandler
 from .logs import LogsHandler
@@ -333,6 +334,30 @@ class TljhRepo2Docker(Application):
         application.listen(self.port, self.ip)
         return application
 
+    async def _cleanup_stale_builds(self):
+        """Mark BUILDING entries as FAILED on startup (server was restarted mid-build)."""
+        if not hasattr(self, "db_context") or not hasattr(self, "image_db_manager"):
+            return
+        async with self.db_context() as db:
+            all_entries = await self.image_db_manager.read_all(db)
+        stale = [e for e in all_entries if e.status == BuildStatusType.BUILDING]
+        if not stale:
+            return
+        self.log.warning(
+            "Found %d build(s) stuck in BUILDING state — marking as FAILED", len(stale)
+        )
+        for entry in stale:
+            async with self.db_context() as db:
+                await self.image_db_manager.update(
+                    db,
+                    DockerImageUpdateSchema(
+                        uid=entry.uid,
+                        status=BuildStatusType.FAILED,
+                        log=(entry.log or "")
+                        + "\n[Build interrupted: server restarted]\n",
+                    ),
+                )
+
     def start(self):
         """Start the server."""
         self.init_db()
@@ -345,6 +370,7 @@ class TljhRepo2Docker(Application):
 
         self.app.listen(self.port, self.ip)
         self.ioloop = ioloop.IOLoop.current()
+        self.ioloop.add_callback(self._cleanup_stale_builds)
         try:
             self.log.info(
                 f"tljh-repo2docker service listening on {self.ip}:{self.port}"

--- a/tljh_repo2docker/binderhub_builder.py
+++ b/tljh_repo2docker/binderhub_builder.py
@@ -79,7 +79,7 @@ class BinderHubBuildHandler(BaseHandler):
         cpu = data["cpu"]
         provider = data["provider"]
         node_selector = data.get("node_selector", {})
-        owner = self.get_current_user().get('name', 'unknow')
+        owner = self.get_current_user().get("name", "unknow")
 
         if len(repo) == 0:
             raise web.HTTPError(400, "Repository is empty")

--- a/tljh_repo2docker/builder.py
+++ b/tljh_repo2docker/builder.py
@@ -1,7 +1,6 @@
 import json
 import re
 from datetime import datetime
-from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from aiodocker import Docker, DockerError
@@ -14,7 +13,7 @@ from .database.schemas import (
     DockerImageUpdateSchema,
     ImageMetadataType,
 )
-from .docker import build_image
+from .docker import build_image, compute_image_name
 
 IMAGE_NAME_RE = r"^[a-z0-9-_]+$"
 
@@ -99,12 +98,7 @@ class BuildHandler(BaseHandler):
                     raise web.HTTPError(400, "Invalid build argument format")
                 extra_buildargs.append(barg)
 
-        # Compute image_name (mirrors logic in docker.py so DB entry matches)
-        ref_norm = ref or "HEAD"
-        ref_short = ref_norm[:7] if len(ref_norm) >= 40 else ref_norm
-        name_norm = name or urlparse(repo).path.strip("/")
-        name_norm = name_norm.lower().replace("/", "-")
-        image_name = f"{name_norm}:{ref_short}"
+        image_name, ref_norm, name_norm = compute_image_name(repo, ref, name)
 
         creation_date = datetime.now().strftime("%d/%m/%Y")
 

--- a/tljh_repo2docker/builder.py
+++ b/tljh_repo2docker/builder.py
@@ -1,10 +1,19 @@
 import json
 import re
+from datetime import datetime
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
 
 from aiodocker import Docker, DockerError
 from tornado import web
 
 from .base import BaseHandler, require_admin_role
+from .database.schemas import (
+    BuildStatusType,
+    DockerImageCreateSchema,
+    DockerImageUpdateSchema,
+    ImageMetadataType,
+)
 from .docker import build_image
 
 IMAGE_NAME_RE = r"^[a-z0-9-_]+$"
@@ -19,12 +28,29 @@ class BuildHandler(BaseHandler):
     @require_admin_role
     async def delete(self):
         data = self.get_json_body()
-        name = data["name"]
+        image_name = data["name"]
+
+        db_context = self.settings.get("db_context")
+        image_db_manager = self.settings.get("image_db_manager")
+
+        db_entry_deleted = False
+        if db_context and image_db_manager:
+            async with db_context() as db:
+                try:
+                    entry = await image_db_manager.read(db, UUID(image_name))
+                except ValueError:
+                    entry = await image_db_manager.read_by_image_name(db, image_name)
+                if entry:
+                    image_name = entry.name
+                    await image_db_manager.delete(db, entry.uid)
+                    db_entry_deleted = True
+
         async with Docker() as docker:
             try:
-                await docker.images.delete(name)
+                await docker.images.delete(image_name)
             except DockerError as e:
-                raise web.HTTPError(e.status, e.message)
+                if e.status != 404 or not db_entry_deleted:
+                    raise web.HTTPError(e.status, e.message)
 
         self.set_status(200)
         self.set_header("content-type", "application/json")
@@ -43,7 +69,7 @@ class BuildHandler(BaseHandler):
         buildargs = data.get("buildargs", None)
         git_username = data.get("username", None)
         git_password = data.get("password", None)
-        owner = self.get_current_user().get('name', 'unknow')
+        owner = self.get_current_user().get("name", "unknow")
 
         if not repo:
             raise web.HTTPError(400, "Repository is empty")
@@ -72,19 +98,73 @@ class BuildHandler(BaseHandler):
                 if "=" not in barg:
                     raise web.HTTPError(400, "Invalid build argument format")
                 extra_buildargs.append(barg)
-        await build_image(
-            repo,
-            ref,
-            node_selector,
-            name,
-            owner,
-            memory,
-            cpu,
-            git_username,
-            git_password,
-            extra_buildargs,
-        )
+
+        # Compute image_name (mirrors logic in docker.py so DB entry matches)
+        ref_norm = ref or "HEAD"
+        ref_short = ref_norm[:7] if len(ref_norm) >= 40 else ref_norm
+        name_norm = name or urlparse(repo).path.strip("/")
+        name_norm = name_norm.lower().replace("/", "-")
+        image_name = f"{name_norm}:{ref_short}"
+
+        creation_date = datetime.now().strftime("%d/%m/%Y")
+
+        db_context = self.settings.get("db_context")
+        image_db_manager = self.settings.get("image_db_manager")
+
+        uid = None
+        if db_context and image_db_manager:
+            uid = uuid4()
+            image_in = DockerImageCreateSchema(
+                uid=uid,
+                name=image_name,
+                status=BuildStatusType.BUILDING,
+                log="",
+                image_meta=ImageMetadataType(
+                    display_name=name_norm,
+                    repo=repo,
+                    ref=ref_norm,
+                    cpu_limit=cpu or "",
+                    mem_limit=memory or "",
+                    creation_date=creation_date,
+                    owner=owner,
+                    node_selector=node_selector,
+                ),
+            )
+            async with db_context() as db:
+                await image_db_manager.create(db, image_in)
 
         self.set_status(200)
         self.set_header("content-type", "application/json")
-        self.finish(json.dumps({"status": "ok"}))
+        response = {"status": "ok"}
+        if uid is not None:
+            response["uid"] = str(uid)
+        self.finish(json.dumps(response))
+
+        try:
+            await build_image(
+                repo,
+                ref,
+                node_selector,
+                name,
+                owner,
+                memory,
+                cpu,
+                git_username,
+                git_password,
+                extra_buildargs,
+                uid=uid,
+                db_context=db_context,
+                image_db_manager=image_db_manager,
+            )
+        except Exception as e:
+            self.log.error("Build failed with exception: %s", e, exc_info=True)
+            if db_context and image_db_manager:
+                async with db_context() as db:
+                    await image_db_manager.update(
+                        db,
+                        DockerImageUpdateSchema(
+                            uid=uid,
+                            status=BuildStatusType.FAILED,
+                            log=str(e),
+                        ),
+                    )

--- a/tljh_repo2docker/database/manager.py
+++ b/tljh_repo2docker/database/manager.py
@@ -16,7 +16,6 @@ from .schemas import (
 
 
 class ImagesDatabaseManager:
-
     @property
     def _table(self) -> Type[DockerImageSQL]:
         return DockerImageSQL

--- a/tljh_repo2docker/database/schemas.py
+++ b/tljh_repo2docker/database/schemas.py
@@ -42,5 +42,4 @@ class DockerImageUpdateSchema(DockerImageCreateSchema):
 
 
 class DockerImageOutSchema(DockerImageCreateSchema):
-
     model_config = ConfigDict(use_enum_values=True, from_attributes=True)

--- a/tljh_repo2docker/dbutil.py
+++ b/tljh_repo2docker/dbutil.py
@@ -197,7 +197,22 @@ def async_session_context_factory(async_db_url: str):
     - AsyncContextManager[AsyncSession]: An asynchronous context manager that yields
       an async session for database interactions within the context.
     """
-    async_engine = create_async_engine(async_db_url)
+    connect_args = {}
+    if async_db_url.startswith("sqlite"):
+        # Allow up to 30 s of retrying on lock; enable WAL for concurrent access
+        connect_args = {"timeout": 30, "check_same_thread": False}
+
+    async_engine = create_async_engine(
+        async_db_url,
+        connect_args=connect_args,
+    )
+
+    if async_db_url.startswith("sqlite"):
+        from sqlalchemy import event as sa_event
+
+        @sa_event.listens_for(async_engine.sync_engine, "connect")
+        def set_wal_mode(dbapi_conn, _):
+            dbapi_conn.execute("PRAGMA journal_mode=WAL")
     async_session_maker = async_sessionmaker(
         async_engine,
         class_=AsyncSession,

--- a/tljh_repo2docker/dbutil.py
+++ b/tljh_repo2docker/dbutil.py
@@ -213,6 +213,7 @@ def async_session_context_factory(async_db_url: str):
         @sa_event.listens_for(async_engine.sync_engine, "connect")
         def set_wal_mode(dbapi_conn, _):
             dbapi_conn.execute("PRAGMA journal_mode=WAL")
+
     async_session_maker = async_sessionmaker(
         async_engine,
         class_=AsyncSession,

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -1,3 +1,4 @@
+import collections
 import json
 from datetime import datetime
 from urllib.parse import urlparse
@@ -6,6 +7,15 @@ from aiodocker import Docker
 from tornado import web
 
 from .database.schemas import BuildStatusType, DockerImageUpdateSchema
+
+LOG_HEAD_LINES = 10
+LOG_TAIL_LINES = 300
+
+
+def _build_log(head, tail, truncated):
+    if not truncated:
+        return "".join(list(head) + list(tail))
+    return "".join(head) + "\n[...truncated...]\n" + "".join(tail)
 
 
 def compute_image_name(repo, ref, name):
@@ -196,28 +206,40 @@ async def build_image(
 
         try:
             if uid and db_context and image_db_manager:
-                log_parts = []
+                head_parts = []
+                tail_parts = collections.deque(maxlen=LOG_TAIL_LINES)
+                line_count = 0
                 pending = 0
                 async for line in container.log(
                     stdout=True, stderr=True, follow=True
                 ):
-                    log_parts.append(line)
+                    if line_count < LOG_HEAD_LINES:
+                        head_parts.append(line)
+                    else:
+                        tail_parts.append(line)
+                    line_count += 1
                     pending += 1
                     if pending >= 10:
+                        truncated = line_count > LOG_HEAD_LINES + LOG_TAIL_LINES
                         async with db_context() as db:
                             await image_db_manager.update(
                                 db,
                                 DockerImageUpdateSchema(
-                                    uid=uid, log="".join(log_parts)
+                                    uid=uid,
+                                    log=_build_log(head_parts, tail_parts, truncated),
                                 ),
                             )
                         pending = 0
                 # Flush remaining lines
                 if pending:
+                    truncated = line_count > LOG_HEAD_LINES + LOG_TAIL_LINES
                     async with db_context() as db:
                         await image_db_manager.update(
                             db,
-                            DockerImageUpdateSchema(uid=uid, log="".join(log_parts)),
+                            DockerImageUpdateSchema(
+                                uid=uid,
+                                log=_build_log(head_parts, tail_parts, truncated),
+                            ),
                         )
 
                 result = await container.wait()

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -42,7 +42,9 @@ async def list_images():
             "ref": image["Labels"]["repo2docker.ref"],
             "image_name": image["Labels"]["tljh_repo2docker.image_name"],
             "display_name": image["Labels"]["tljh_repo2docker.display_name"],
-            "creation_date": image["Labels"].get("tljh_repo2docker.creation_date", "unknow"),
+            "creation_date": image["Labels"].get(
+                "tljh_repo2docker.creation_date", "unknow"
+            ),
             "owner": image["Labels"].get("tljh_repo2docker.owner", "unknow"),
             "mem_limit": image["Labels"]["tljh_repo2docker.mem_limit"],
             "cpu_limit": image["Labels"]["tljh_repo2docker.cpu_limit"],
@@ -197,7 +199,9 @@ async def build_image(
     if git_username and git_password:
         config.update(
             {
-                "Env": [f"GIT_CREDENTIAL_ENV=username={git_username}\npassword={git_password}"],
+                "Env": [
+                    f"GIT_CREDENTIAL_ENV=username={git_username}\npassword={git_password}"
+                ],
             }
         )
 
@@ -210,9 +214,7 @@ async def build_image(
                 tail_parts = collections.deque(maxlen=LOG_TAIL_LINES)
                 line_count = 0
                 pending = 0
-                async for line in container.log(
-                    stdout=True, stderr=True, follow=True
-                ):
+                async for line in container.log(stdout=True, stderr=True, follow=True):
                     if line_count < LOG_HEAD_LINES:
                         head_parts.append(line)
                     else:

--- a/tljh_repo2docker/docker.py
+++ b/tljh_repo2docker/docker.py
@@ -1,9 +1,21 @@
 import json
-from urllib.parse import urlparse
 from datetime import datetime
+from urllib.parse import urlparse
 
 from aiodocker import Docker
 from tornado import web
+
+from .database.schemas import BuildStatusType, DockerImageUpdateSchema
+
+
+def compute_image_name(repo, ref, name):
+    """Return the Docker image name derived from repo/ref/name."""
+    ref = ref or "HEAD"
+    if len(ref) >= 40:
+        ref = ref[:7]
+    name = name or urlparse(repo).path.strip("/")
+    name = name.lower().replace("/", "-")
+    return f"{name}:{ref}", ref, name
 
 
 async def list_images():
@@ -96,19 +108,16 @@ async def build_image(
     git_username=None,
     git_password=None,
     extra_buildargs=None,
+    uid=None,
+    db_context=None,
+    image_db_manager=None,
 ):
     """
-    Build an image given a repo, ref and limits
+    Build an image given a repo, ref and limits.
+    When uid/db_context/image_db_manager are provided, logs are streamed to
+    the database in real time and the final status (built/failed) is persisted.
     """
-    ref = ref or "HEAD"
-    if len(ref) >= 40:
-        ref = ref[:7]
-
-    # default to the repo name if no name specified
-    # and sanitize the name of the docker image
-    name = name or urlparse(repo).path.strip("/")
-    name = name.lower().replace("/", "-")
-    image_name = f"{name}:{ref}"
+    image_name, ref, name = compute_image_name(repo, ref, name)
 
     # memory is specified in GB
     memory = f"{memory}G" if memory else ""
@@ -183,4 +192,47 @@ async def build_image(
         )
 
     async with Docker() as docker:
-        await docker.containers.run(config=config)
+        container = await docker.containers.run(config=config)
+
+        try:
+            if uid and db_context and image_db_manager:
+                log_parts = []
+                pending = 0
+                async for line in container.log(
+                    stdout=True, stderr=True, follow=True
+                ):
+                    log_parts.append(line)
+                    pending += 1
+                    if pending >= 10:
+                        async with db_context() as db:
+                            await image_db_manager.update(
+                                db,
+                                DockerImageUpdateSchema(
+                                    uid=uid, log="".join(log_parts)
+                                ),
+                            )
+                        pending = 0
+                # Flush remaining lines
+                if pending:
+                    async with db_context() as db:
+                        await image_db_manager.update(
+                            db,
+                            DockerImageUpdateSchema(uid=uid, log="".join(log_parts)),
+                        )
+
+                result = await container.wait()
+                exit_code = result.get("StatusCode", -1)
+                status = (
+                    BuildStatusType.BUILT if exit_code == 0 else BuildStatusType.FAILED
+                )
+                async with db_context() as db:
+                    await image_db_manager.update(
+                        db, DockerImageUpdateSchema(uid=uid, status=status)
+                    )
+            else:
+                # No DB context: drain logs to allow the container to finish
+                async for _ in container.log(stdout=True, stderr=True, follow=True):
+                    pass
+                await container.wait()
+        finally:
+            await container.delete()

--- a/tljh_repo2docker/environments.py
+++ b/tljh_repo2docker/environments.py
@@ -3,6 +3,7 @@ from inspect import isawaitable
 from tornado import web
 
 from .base import BaseHandler, require_admin_role
+from .database.schemas import BuildStatusType
 from .docker import list_containers, list_images
 
 
@@ -23,6 +24,13 @@ class EnvironmentsHandler(BaseHandler):
             containers = await list_containers()
             all_images = images + containers
 
+            db_context = self.settings.get("db_context")
+            image_db_manager = self.settings.get("image_db_manager")
+            if db_context and image_db_manager:
+                all_images = await self._enrich_with_db(
+                    all_images, db_context, image_db_manager
+                )
+
         result = self.render_template(
             "images.html",
             images=all_images,
@@ -37,3 +45,34 @@ class EnvironmentsHandler(BaseHandler):
             self.write(await result)
         else:
             self.write(result)
+
+    async def _enrich_with_db(self, images, db_context, image_db_manager):
+        """
+        Enrich Docker images with their DB uid, and append FAILED or BUILDING
+        images that are only in the DB (no Docker image/container yet).
+        """
+        async with db_context() as db:
+            all_db_entries = await image_db_manager.read_all(db)
+
+        db_by_name = {entry.name: entry for entry in all_db_entries}
+        docker_names = {img["image_name"] for img in images}
+
+        # Add uid to images that have a matching DB entry
+        for image in images:
+            entry = db_by_name.get(image["image_name"])
+            if entry:
+                image["uid"] = str(entry.uid)
+
+        extra = [
+            dict(
+                image_name=entry.name,
+                uid=str(entry.uid),
+                status=entry.status,
+                **entry.image_meta.model_dump(),
+            )
+            for entry in all_db_entries
+            if entry.status in (BuildStatusType.FAILED, BuildStatusType.BUILDING)
+            and entry.name not in docker_names
+        ]
+
+        return images + extra

--- a/tljh_repo2docker/logs.py
+++ b/tljh_repo2docker/logs.py
@@ -9,6 +9,7 @@ from .base import BaseHandler, require_admin_role
 from .database.schemas import BuildStatusType
 
 TIME_OUT = 3600
+POLL_INTERVAL = 3
 
 
 class LogsHandler(BaseHandler):
@@ -50,8 +51,8 @@ class LogsHandler(BaseHandler):
 
         elapsed = 0
         while elapsed < TIME_OUT:
-            elapsed += 1
-            await asyncio.sleep(1)
+            elapsed += POLL_INTERVAL
+            await asyncio.sleep(POLL_INTERVAL)
             image = await self._lookup(name, db_context, image_db_manager)
             if not image:
                 await self._emit({"phase": "error", "message": "Image not found"})

--- a/tljh_repo2docker/logs.py
+++ b/tljh_repo2docker/logs.py
@@ -58,9 +58,7 @@ class LogsHandler(BaseHandler):
                 return
             log = image.log or ""
             if len(log) > current_log_length:
-                await self._emit(
-                    {"phase": "log", "message": log[current_log_length:]}
-                )
+                await self._emit({"phase": "log", "message": log[current_log_length:]})
                 current_log_length = len(log)
             status = image.status
             if status == BuildStatusType.FAILED:

--- a/tljh_repo2docker/logs.py
+++ b/tljh_repo2docker/logs.py
@@ -62,10 +62,10 @@ class LogsHandler(BaseHandler):
                 current_log_length = len(log)
             status = image.status
             if status == BuildStatusType.FAILED:
-                await self._emit({"phase": "error", "message": ""})
+                await self._emit({"phase": "error", "message": log})
                 return
             if status == BuildStatusType.BUILT:
-                await self._emit({"phase": "built", "message": ""})
+                await self._emit({"phase": "built", "message": log})
                 return
 
         await self._emit({"phase": "error", "message": "Build timed out"})

--- a/tljh_repo2docker/logs.py
+++ b/tljh_repo2docker/logs.py
@@ -1,15 +1,21 @@
+import asyncio
 import json
+from uuid import UUID
 
-from aiodocker import Docker
 from tornado import web
 from tornado.iostream import StreamClosedError
 
 from .base import BaseHandler, require_admin_role
+from .database.schemas import BuildStatusType
+
+TIME_OUT = 3600
 
 
 class LogsHandler(BaseHandler):
     """
     Expose a handler to follow the build logs.
+    Reads from the database (polling for BUILDING, immediate for BUILT/FAILED).
+    Accepts both a UUID or an image name as the identifier.
     """
 
     @web.authenticated
@@ -18,18 +24,61 @@ class LogsHandler(BaseHandler):
         self.set_header("Content-Type", "text/event-stream")
         self.set_header("Cache-Control", "no-cache")
 
-        async with Docker() as docker:
-            containers = await docker.containers.list(
-                filters=json.dumps({"label": [f"repo2docker.build={name}"]})
-            )
+        db_context = self.settings.get("db_context")
+        image_db_manager = self.settings.get("image_db_manager")
 
-            if not containers:
-                raise web.HTTPError(404, f"No logs for image: {name}")
+        if not db_context or not image_db_manager:
+            raise web.HTTPError(500, "Database not configured")
 
-            async for line in containers[0].log(stdout=True, stderr=True, follow=True):
-                await self._emit({"phase": "log", "message": line})
+        image = await self._lookup(name, db_context, image_db_manager)
+        if not image:
+            raise web.HTTPError(404, f"No logs for image: {name}")
 
-        await self._emit({"phase": "built", "message": "built"})
+        status = image.status
+
+        if status == BuildStatusType.FAILED:
+            await self._emit({"phase": "error", "message": image.log or ""})
+            return
+
+        if status == BuildStatusType.BUILT:
+            await self._emit({"phase": "built", "message": image.log or ""})
+            return
+
+        # BUILDING: send what we have, then poll for new lines
+        current_log_length = len(image.log or "")
+        await self._emit({"phase": "log", "message": image.log or ""})
+
+        elapsed = 0
+        while elapsed < TIME_OUT:
+            elapsed += 1
+            await asyncio.sleep(1)
+            image = await self._lookup(name, db_context, image_db_manager)
+            if not image:
+                await self._emit({"phase": "error", "message": "Image not found"})
+                return
+            log = image.log or ""
+            if len(log) > current_log_length:
+                await self._emit(
+                    {"phase": "log", "message": log[current_log_length:]}
+                )
+                current_log_length = len(log)
+            status = image.status
+            if status == BuildStatusType.FAILED:
+                await self._emit({"phase": "error", "message": ""})
+                return
+            if status == BuildStatusType.BUILT:
+                await self._emit({"phase": "built", "message": ""})
+                return
+
+        await self._emit({"phase": "error", "message": "Build timed out"})
+
+    async def _lookup(self, name, db_context, image_db_manager):
+        """Look up an image by UUID or image name."""
+        async with db_context() as db:
+            try:
+                return await image_db_manager.read(db, UUID(name))
+            except ValueError:
+                return await image_db_manager.read_by_image_name(db, name)
 
     async def _emit(self, msg):
         try:

--- a/tljh_repo2docker/model.py
+++ b/tljh_repo2docker/model.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass, fields
 
 @dataclass
 class UserModel:
-
     name: str
     admin: bool
     servers: dict

--- a/tljh_repo2docker/servers.py
+++ b/tljh_repo2docker/servers.py
@@ -43,9 +43,9 @@ class ServersHandler(BaseHandler):
                         )
                         if db_data:
                             data["user_options"]["uid"] = str(db_data.uid)
-                            data["user_options"][
-                                "display_name"
-                            ] = db_data.image_meta.display_name
+                            data["user_options"]["display_name"] = (
+                                db_data.image_meta.display_name
+                            )
         named_server_limit = 0
         result = self.render_template(
             "servers.html",

--- a/tljh_repo2docker/tests/binderhub_build/conftest.py
+++ b/tljh_repo2docker/tests/binderhub_build/conftest.py
@@ -96,6 +96,9 @@ def db_session():
     )
 
     session = Session()
+    # Clean any leftover entries from previous test suites
+    session.query(DockerImageSQL).delete()
+    session.commit()
     yield session
     session.query(DockerImageSQL).delete()
     session.commit()

--- a/tljh_repo2docker/tests/binderhub_build/test_builder.py
+++ b/tljh_repo2docker/tests/binderhub_build/test_builder.py
@@ -30,9 +30,13 @@ async def test_add_environment(
 
     await wait_for_image(image_name=generated_image_name)
     await asyncio.sleep(3)
-    images_db = db_session.execute(
-        sa.select(DockerImageSQL).where(DockerImageSQL.uid == UUID(uid))
-    ).scalars().first()
+    images_db = (
+        db_session.execute(
+            sa.select(DockerImageSQL).where(DockerImageSQL.uid == UUID(uid))
+        )
+        .scalars()
+        .first()
+    )
     assert images_db is not None
     assert images_db.name == generated_image_name
     assert images_db.image_meta["display_name"] == name

--- a/tljh_repo2docker/tests/binderhub_build/test_builder.py
+++ b/tljh_repo2docker/tests/binderhub_build/test_builder.py
@@ -1,4 +1,5 @@
 import asyncio
+from uuid import UUID
 
 import pytest
 import sqlalchemy as sa
@@ -29,7 +30,10 @@ async def test_add_environment(
 
     await wait_for_image(image_name=generated_image_name)
     await asyncio.sleep(3)
-    images_db = db_session.execute(sa.select(DockerImageSQL)).scalars().first()
+    images_db = db_session.execute(
+        sa.select(DockerImageSQL).where(DockerImageSQL.uid == UUID(uid))
+    ).scalars().first()
+    assert images_db is not None
     assert images_db.name == generated_image_name
     assert images_db.image_meta["display_name"] == name
     assert images_db.image_meta["ref"] == ref

--- a/tljh_repo2docker/tests/local_build/conftest.py
+++ b/tljh_repo2docker/tests/local_build/conftest.py
@@ -1,9 +1,11 @@
 import sys
 
 import pytest
+import sqlalchemy as sa
 from traitlets.config import Config
 
 from tljh_repo2docker import tljh_custom_jupyterhub_config
+from tljh_repo2docker.database.model import DockerImageSQL
 
 
 @pytest.fixture(scope="module")
@@ -51,3 +53,16 @@ async def app(hub_app):
 
     app = await hub_app(config=config)
     return app
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    """Delete all DB entries after each test to avoid cross-test contamination."""
+    yield
+    try:
+        engine = sa.create_engine("sqlite:///tljh_repo2docker.sqlite")
+        with engine.begin() as conn:
+            conn.execute(sa.delete(DockerImageSQL))
+        engine.dispose()
+    except Exception:
+        pass

--- a/tljh_repo2docker/tests/local_build/test_builder.py
+++ b/tljh_repo2docker/tests/local_build/test_builder.py
@@ -79,3 +79,26 @@ async def test_wrong_limits(app, minimal_repo, image_name, memory, cpu, node_sel
 async def test_wrong_name(app, minimal_repo):
     r = await add_environment(app, repo=minimal_repo, name="#WRONG_NAME#")
     assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_build_response_contains_uid(app, minimal_repo, image_name):
+    name, ref = image_name.split(":")
+    r = await add_environment(app, repo=minimal_repo, name=name, ref=ref)
+    assert r.status_code == 200
+    data = r.json()
+    assert "uid" in data
+    assert data["uid"]
+    await wait_for_image(image_name=image_name)
+
+
+@pytest.mark.asyncio
+async def test_delete_by_uid(app, minimal_repo, image_name):
+    name, ref = image_name.split(":")
+    r = await add_environment(app, repo=minimal_repo, name=name, ref=ref)
+    assert r.status_code == 200
+    uid = r.json()["uid"]
+    await wait_for_image(image_name=image_name)
+
+    r = await remove_environment(app, image_name=uid)
+    assert r.status_code == 200

--- a/tljh_repo2docker/tests/local_build/test_db_manager.py
+++ b/tljh_repo2docker/tests/local_build/test_db_manager.py
@@ -1,0 +1,172 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from tljh_repo2docker.database.manager import ImagesDatabaseManager
+from tljh_repo2docker.database.model import BaseSQL
+from tljh_repo2docker.database.schemas import (
+    BuildStatusType,
+    DockerImageCreateSchema,
+    DockerImageUpdateSchema,
+    ImageMetadataType,
+)
+
+
+@pytest.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(BaseSQL.metadata.create_all)
+    maker = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autocommit=False,
+        autoflush=False,
+    )
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+def _make_schema(
+    uid=None, name="test-image:HEAD", status=BuildStatusType.BUILDING
+):
+    return DockerImageCreateSchema(
+        uid=uid or uuid4(),
+        name=name,
+        status=status,
+        log="",
+        image_meta=ImageMetadataType(
+            display_name="test-image",
+            repo="https://github.com/test/test",
+            ref="HEAD",
+            creation_date="01/01/2025",
+            owner="admin",
+            cpu_limit="",
+            mem_limit="",
+            node_selector={},
+        ),
+    )
+
+
+async def test_create_and_read(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema()
+    created = await manager.create(db_session, schema)
+
+    assert created.uid == schema.uid
+    assert created.status == BuildStatusType.BUILDING.value
+    assert created.name == "test-image:HEAD"
+
+    fetched = await manager.read(db_session, schema.uid)
+    assert fetched is not None
+    assert fetched.uid == schema.uid
+
+
+async def test_read_by_image_name(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema(name="unique-image:abc")
+    await manager.create(db_session, schema)
+
+    result = await manager.read_by_image_name(db_session, "unique-image:abc")
+    assert result is not None
+    assert result.uid == schema.uid
+
+
+async def test_read_by_image_name_not_found(db_session):
+    manager = ImagesDatabaseManager()
+    result = await manager.read_by_image_name(db_session, "no-such-image:xyz")
+    assert result is None
+
+
+async def test_read_all(db_session):
+    manager = ImagesDatabaseManager()
+    for i in range(3):
+        await manager.create(db_session, _make_schema(name=f"img-{i}:HEAD"))
+
+    all_images = await manager.read_all(db_session)
+    assert len(all_images) == 3
+
+
+async def test_update_status(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema()
+    await manager.create(db_session, schema)
+
+    await manager.update(
+        db_session,
+        DockerImageUpdateSchema(uid=schema.uid, status=BuildStatusType.BUILT),
+    )
+    updated = await manager.read(db_session, schema.uid)
+    assert updated is not None
+    assert updated.status == BuildStatusType.BUILT.value
+
+
+async def test_update_log(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema()
+    await manager.create(db_session, schema)
+
+    await manager.update(
+        db_session,
+        DockerImageUpdateSchema(uid=schema.uid, log="some log content"),
+    )
+    updated = await manager.read(db_session, schema.uid)
+    assert updated is not None
+    assert updated.log == "some log content"
+
+
+async def test_update_log_accumulation(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema()
+    await manager.create(db_session, schema)
+
+    await manager.update(
+        db_session,
+        DockerImageUpdateSchema(uid=schema.uid, log="line1\nline2\n"),
+    )
+    await manager.update(
+        db_session,
+        DockerImageUpdateSchema(uid=schema.uid, log="line1\nline2\nline3\n"),
+    )
+    updated = await manager.read(db_session, schema.uid)
+    assert updated is not None
+    assert "line3" in updated.log
+
+
+async def test_delete(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema()
+    await manager.create(db_session, schema)
+
+    deleted = await manager.delete(db_session, schema.uid)
+    assert deleted is True
+
+    result = await manager.read(db_session, schema.uid)
+    assert result is None
+
+
+async def test_delete_nonexistent(db_session):
+    manager = ImagesDatabaseManager()
+    deleted = await manager.delete(db_session, uuid4())
+    assert deleted is False
+
+
+async def test_failed_image_has_log(db_session):
+    manager = ImagesDatabaseManager()
+    schema = _make_schema(status=BuildStatusType.FAILED)
+    schema_with_log = DockerImageCreateSchema(
+        **{**schema.model_dump(), "log": "Error: build failed"}
+    )
+    await manager.create(db_session, schema_with_log)
+
+    fetched = await manager.read(db_session, schema.uid)
+    assert fetched is not None
+    assert fetched.status == BuildStatusType.FAILED.value
+    assert "Error" in fetched.log

--- a/tljh_repo2docker/tests/local_build/test_db_manager.py
+++ b/tljh_repo2docker/tests/local_build/test_db_manager.py
@@ -34,9 +34,7 @@ async def db_session():
     await engine.dispose()
 
 
-def _make_schema(
-    uid=None, name="test-image:HEAD", status=BuildStatusType.BUILDING
-):
+def _make_schema(uid=None, name="test-image:HEAD", status=BuildStatusType.BUILDING):
     return DockerImageCreateSchema(
         uid=uid or uuid4(),
         name=name,

--- a/tljh_repo2docker/tests/local_build/test_docker.py
+++ b/tljh_repo2docker/tests/local_build/test_docker.py
@@ -1,0 +1,51 @@
+from tljh_repo2docker.docker import compute_image_name
+
+
+def test_compute_image_name_explicit():
+    image_name, ref, name = compute_image_name(
+        "https://github.com/foo/bar", "abc123", "myenv"
+    )
+    assert image_name == "myenv:abc123"
+    assert ref == "abc123"
+    assert name == "myenv"
+
+
+def test_compute_image_name_truncates_long_ref():
+    long_ref = "a" * 40
+    image_name, ref, _ = compute_image_name(
+        "https://github.com/foo/bar", long_ref, "myenv"
+    )
+    assert ref == "aaaaaaa"
+    assert image_name == "myenv:aaaaaaa"
+
+
+def test_compute_image_name_short_ref_not_truncated():
+    ref_39 = "b" * 39
+    _, ref, _ = compute_image_name("https://github.com/foo/bar", ref_39, "myenv")
+    assert ref == ref_39
+
+
+def test_compute_image_name_empty_ref_defaults_to_head():
+    image_name, ref, _ = compute_image_name(
+        "https://github.com/foo/bar", "", "myenv"
+    )
+    assert ref == "HEAD"
+    assert image_name == "myenv:HEAD"
+
+
+def test_compute_image_name_none_ref_defaults_to_head():
+    _, ref, _ = compute_image_name("https://github.com/foo/bar", None, "myenv")
+    assert ref == "HEAD"
+
+
+def test_compute_image_name_derives_name_from_repo():
+    image_name, _, name = compute_image_name(
+        "https://github.com/MyOrg/MyRepo", "main", ""
+    )
+    assert name == "myorg/myrepo".replace("/", "-")
+    assert image_name == "myorg-myrepo:main"
+
+
+def test_compute_image_name_lowercases_explicit_name():
+    _, _, name = compute_image_name("https://github.com/foo/bar", "main", "MyEnv")
+    assert name == "myenv"

--- a/tljh_repo2docker/tests/local_build/test_docker.py
+++ b/tljh_repo2docker/tests/local_build/test_docker.py
@@ -26,9 +26,7 @@ def test_compute_image_name_short_ref_not_truncated():
 
 
 def test_compute_image_name_empty_ref_defaults_to_head():
-    image_name, ref, _ = compute_image_name(
-        "https://github.com/foo/bar", "", "myenv"
-    )
+    image_name, ref, _ = compute_image_name("https://github.com/foo/bar", "", "myenv")
     assert ref == "HEAD"
     assert image_name == "myenv:HEAD"
 

--- a/tljh_repo2docker/tests/local_build/test_logs.py
+++ b/tljh_repo2docker/tests/local_build/test_logs.py
@@ -14,11 +14,23 @@ async def test_stream_simple(app, minimal_repo, image_name):
     assert r.headers["content-type"] == "text/event-stream"
     ex = async_requests.executor
     line_iter = iter(r.iter_lines(decode_unicode=True))
-    evt = await ex.submit(next_event, line_iter)
-    assert "Picked Git content provider" in evt["message"]
+
+    # Read all events until build finishes (DB-based streaming sends incremental
+    # updates; we accumulate the full log across events)
+    full_log = ""
+    final_phase = None
+    while True:
+        evt = await ex.submit(next_event, line_iter)  # type: ignore[misc]
+        if evt is None:
+            break
+        full_log += evt.get("message", "")
+        if evt.get("phase") in ("built", "error"):
+            final_phase = evt["phase"]
+            break
 
     r.close()
-    await wait_for_image(image_name=image_name)
+    assert final_phase == "built"
+    assert "Picked Git content provider" in full_log
 
 
 @pytest.mark.asyncio

--- a/tljh_repo2docker/tests/local_build/test_logs.py
+++ b/tljh_repo2docker/tests/local_build/test_logs.py
@@ -1,5 +1,15 @@
+from uuid import uuid4
+
 import pytest
 from jupyterhub.tests.utils import async_requests
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from tljh_repo2docker.database.manager import ImagesDatabaseManager
+from tljh_repo2docker.database.schemas import (
+    BuildStatusType,
+    DockerImageCreateSchema,
+    ImageMetadataType,
+)
 
 from ..utils import add_environment, api_request, next_event, wait_for_image
 
@@ -40,3 +50,75 @@ async def test_no_build(app, image_name, request):
     )
     request.addfinalizer(r.close)
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_logs_stream_by_uid(app, minimal_repo, image_name):
+    name, ref = image_name.split(":")
+    r = await add_environment(app, repo=minimal_repo, name=name, ref=ref)
+    assert r.status_code == 200
+    uid = r.json()["uid"]
+
+    r = await api_request(app, "environments", uid, "logs", stream=True)
+    r.raise_for_status()
+    assert r.headers["content-type"] == "text/event-stream"
+
+    ex = async_requests.executor
+    line_iter = iter(r.iter_lines(decode_unicode=True))
+    evt = await ex.submit(next_event, line_iter)  # type: ignore[misc]
+    assert evt is not None
+    assert "message" in evt
+
+    r.close()
+    await wait_for_image(image_name=image_name)
+
+
+@pytest.mark.asyncio
+async def test_logs_failed_image(app, image_name):
+    """Logs endpoint returns phase=error immediately for a FAILED image."""
+    uid = uuid4()
+    error_msg = "Build failed: invalid Dockerfile"
+
+    engine = create_async_engine("sqlite+aiosqlite:///tljh_repo2docker.sqlite")
+    maker = async_sessionmaker(
+        engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autocommit=False,
+        autoflush=False,
+    )
+    manager = ImagesDatabaseManager()
+    async with maker() as session:
+        await manager.create(
+            session,
+            DockerImageCreateSchema(
+                uid=uid,
+                name=image_name,
+                status=BuildStatusType.FAILED,
+                log=error_msg,
+                image_meta=ImageMetadataType(
+                    display_name="test",
+                    repo="https://github.com/test/test",
+                    ref="HEAD",
+                    creation_date="01/01/2025",
+                    owner="admin",
+                    cpu_limit="",
+                    mem_limit="",
+                    node_selector={},
+                ),
+            ),
+        )
+    await engine.dispose()
+
+    r = await api_request(app, "environments", str(uid), "logs", stream=True)
+    r.raise_for_status()
+    assert r.headers["content-type"] == "text/event-stream"
+
+    ex = async_requests.executor
+    line_iter = iter(r.iter_lines(decode_unicode=True))
+    evt = await ex.submit(next_event, line_iter)  # type: ignore[misc]
+    r.close()
+
+    assert evt is not None
+    assert evt.get("phase") == "error"
+    assert error_msg in evt.get("message", "")


### PR DESCRIPTION
This PR introduces a database-backed approach to track image builds and logs.

Create a DB entry at build start and return a uid
Stream and persist logs in the database
Store and expose build status (building, failed, succeeded)
Add endpoints to fetch logs and delete by uid
Update UI to show failed builds and view logs
Add unit and integration tests (SQLite in-memory)

This decouples build state from Docker, improving reliability and observability.

Feedback welcome, especially on the API and log storage approach.