### PR TITLE
Fix rebuild showing the environment twice

### DIFF
--- a/tljh_repo2docker/environments.py
+++ b/tljh_repo2docker/environments.py
@@ -18,6 +18,9 @@ async def build_image_list(handler):
 
     images = await list_images()
     containers = await list_containers()
+
+    building_names = {container["image_name"] for container in containers}
+    images = [img for img in images if img["image_name"] not in building_names]
     all_images = images + containers
 
     db_context = handler.settings.get("db_context")

--- a/tljh_repo2docker/tests/local_build/test_builder.py
+++ b/tljh_repo2docker/tests/local_build/test_builder.py
@@ -263,6 +263,27 @@ async def test_get_environments_returns_json(app, minimal_repo, image_name):
 
 
 @pytest.mark.asyncio
+async def test_build_image_list_dedupes_rebuilding_image(monkeypatch):
+    from tljh_repo2docker import environments
+
+    async def fake_list_images():
+        return [{"image_name": "env:HEAD", "status": "built"}]
+
+    async def fake_list_containers():
+        return [{"image_name": "env:HEAD", "status": "building"}]
+
+    monkeypatch.setattr(environments, "list_images", fake_list_images)
+    monkeypatch.setattr(environments, "list_containers", fake_list_containers)
+
+    class _Handler:
+        use_binderhub = False
+        settings: dict = {}
+
+    result = await environments.build_image_list(_Handler())
+    assert result == [{"image_name": "env:HEAD", "status": "building"}]
+
+
+@pytest.mark.asyncio
 async def test_get_environments_serializes_db_only_entries(app):
     # DB-only rows (no matching Docker image) exercise the _enrich_with_db
     # `extra` branch. They carry an enum status and image_meta fields that


### PR DESCRIPTION
During a rebuild the previous image stays tagged while the new build container runs under the same image_name, so build_image_list returned both a built row (old image) and a building row (new container). Drop the stale built image when a build container exists for the same name so the environment keeps a single row that updates in place.