### PR TITLE
Upgrade JavaScript dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@mui/icons-material": "^7.3.8",
                 "@mui/material": "^7.3.8",
                 "@mui/x-data-grid": "^7.29.12",
-                "axios": "^1.17.0",
+                "axios": "^1.20.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
                 "url-join": "^5.0.0",
@@ -2254,13 +2254,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-            "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+            "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.16.0",
-                "form-data": "^4.0.5",
+                "form-data": "^4.0.6",
                 "https-proxy-agent": "^5.0.1",
                 "proxy-from-env": "^2.1.0"
             }
@@ -3725,9 +3725,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "dev": true,
             "funding": [
                 {
@@ -3876,16 +3876,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -4281,9 +4281,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.6.tgz",
-            "integrity": "sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==",
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+            "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
             "dev": true,
             "license": "MIT"
         },
@@ -4861,9 +4861,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {
@@ -5264,9 +5264,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "dev": true,
             "funding": [
                 {
@@ -5780,9 +5780,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.28",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+            "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
             "dev": true,
             "funding": [
                 {
@@ -5800,7 +5800,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.18",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@mui/icons-material": "^7.3.8",
         "@mui/material": "^7.3.8",
         "@mui/x-data-grid": "^7.29.12",
-        "axios": "^1.17.0",
+        "axios": "^1.20.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "url-join": "^5.0.0",

--- a/ui-tests/package-lock.json
+++ b/ui-tests/package-lock.json
@@ -38,15 +38,15 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/fsevents": {


### PR DESCRIPTION
Bundles the pending Dependabot updates, all semver-compatible:

- axios 1.17.0 -> 1.20.0 (direct dependency, range bumped to ^1.18.0)
- fast-uri 3.1.2 -> 3.1.7
- form-data 4.0.5 -> 4.0.6
- immutable 5.1.6 -> 5.1.9
- js-yaml 4.2.0 -> 4.3.2
- nanoid 3.3.12 -> 3.3.18
- postcss 8.5.15 -> 8.5.28
- brace-expansion 5.0.5 -> 5.0.9 (ui-tests)

Verified with npm run build:prod and npm run lint:check.